### PR TITLE
Show graphical characters instead of alphabet on ovmenu

### DIFF
--- a/recipes-apps/ovmenu-ng/files/openvario-57-lvds/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-57-lvds/ovmenu-ng.sh
@@ -370,7 +370,7 @@ function yesno_power_off(){
 	esac
 }
 
-setfont cp866-8x14.psf.gz
+setfont default8x16
 
 DIALOG_CANCEL=1 dialog --nook --nocancel --pause "Starting XCSoar ... \\n Press [ESC] for menu" 10 30 $TIMEOUT 2>&1
 


### PR DESCRIPTION
ovmenu showed alphaet characters as surrounding frame. Replace them by graphical characters. 

Signed-off-by: Caz Yokoyama <caz@caztech.com>