### PR TITLE
Upgrade to mesa-20.0.0

### DIFF
--- a/conf/machine/openvario-43-rgb.conf
+++ b/conf/machine/openvario-43-rgb.conf
@@ -41,21 +41,6 @@ SPL_BINARY ?= "u-boot-sunxi-with-spl.bin"
 SERIAL_CONSOLE ?= "115200 ttyS0"
 MACHINE_FEATURES ?= "alsa apm keyboard rtc serial screen usbgadget usbhost vfat"
 
-PREFERRED_PROVIDER_virtual/mesa ?= "mesa-gl"
-PREFERRED_PROVIDER_virtual/libgl ?= "mesa-gl"
-PREFERRED_PROVIDER_virtual/libgles1 ?= "mali-blobs-sunxi"
-PREFERRED_PROVIDER_virtual/libgles2 ?= "mali-blobs-sunxi"
-PREFERRED_PROVIDER_virtual/egl ?= "mali-blobs-sunxi"
-
-XSERVER += "mali-blobs-sunxi \
-            mali-blobs-sunxi-dev"
-
-MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "\
- kernel-module-mali \
- kernel-module-mali-drm \
-  "
-
-
 SOC_FAMILY = "sun7i"
 
 KERNEL_DEVICETREE_SOURCE = "openvario-43-rgb.dts"

--- a/conf/machine/openvario-57-lvds.conf
+++ b/conf/machine/openvario-57-lvds.conf
@@ -41,21 +41,6 @@ SPL_BINARY ?= "u-boot-sunxi-with-spl.bin"
 SERIAL_CONSOLE ?= "115200 ttyS0"
 MACHINE_FEATURES ?= "alsa apm keyboard rtc serial screen usbgadget usbhost vfat"
 
-PREFERRED_PROVIDER_virtual/mesa ?= "mesa-gl"
-PREFERRED_PROVIDER_virtual/libgl ?= "mesa-gl"
-PREFERRED_PROVIDER_virtual/libgles1 ?= "mali-blobs-sunxi"
-PREFERRED_PROVIDER_virtual/libgles2 ?= "mali-blobs-sunxi"
-PREFERRED_PROVIDER_virtual/egl ?= "mali-blobs-sunxi"
-
-XSERVER += "mali-blobs-sunxi \
-            mali-blobs-sunxi-dev"
-
-MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "\
- kernel-module-mali \
- kernel-module-mali-drm \
-  "
-
-
 SOC_FAMILY = "sun7i"
 
 KERNEL_DEVICETREE_SOURCE = "openvario-57-lvds.dts"

--- a/conf/machine/openvario-7-CH070.conf
+++ b/conf/machine/openvario-7-CH070.conf
@@ -41,21 +41,6 @@ SPL_BINARY ?= "u-boot-sunxi-with-spl.bin"
 SERIAL_CONSOLE ?= "115200 ttyS0"
 MACHINE_FEATURES ?= "alsa apm keyboard rtc serial screen usbgadget usbhost vfat"
 
-PREFERRED_PROVIDER_virtual/mesa ?= "mesa-gl"
-PREFERRED_PROVIDER_virtual/libgl ?= "mesa-gl"
-PREFERRED_PROVIDER_virtual/libgles1 ?= "mali-blobs-sunxi"
-PREFERRED_PROVIDER_virtual/libgles2 ?= "mali-blobs-sunxi"
-PREFERRED_PROVIDER_virtual/egl ?= "mali-blobs-sunxi"
-
-XSERVER += "mali-blobs-sunxi \
-            mali-blobs-sunxi-dev"
-
-MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "\
- kernel-module-mali \
- kernel-module-mali-drm \
-  "
-
-
 SOC_FAMILY = "sun7i"
 
 KERNEL_DEVICETREE_SOURCE = "openvario-7-CH070.dts"

--- a/conf/machine/openvario-7-PQ070.conf
+++ b/conf/machine/openvario-7-PQ070.conf
@@ -41,21 +41,6 @@ SPL_BINARY ?= "u-boot-sunxi-with-spl.bin"
 SERIAL_CONSOLE ?= "115200 ttyS0"
 MACHINE_FEATURES ?= "alsa apm keyboard rtc serial screen usbgadget usbhost vfat"
 
-PREFERRED_PROVIDER_virtual/mesa ?= "mesa-gl"
-PREFERRED_PROVIDER_virtual/libgl ?= "mesa-gl"
-PREFERRED_PROVIDER_virtual/libgles1 ?= "mali-blobs-sunxi"
-PREFERRED_PROVIDER_virtual/libgles2 ?= "mali-blobs-sunxi"
-PREFERRED_PROVIDER_virtual/egl ?= "mali-blobs-sunxi"
-
-XSERVER += "mali-blobs-sunxi \
-            mali-blobs-sunxi-dev"
-
-MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "\
- kernel-module-mali \
- kernel-module-mali-drm \
-  "
-
-
 SOC_FAMILY = "sun7i"
 
 KERNEL_DEVICETREE_SOURCE = "openvario-7-PQ070.dts"

--- a/recipes-graphics/mesa/files/0001-meson-misdetects-64bit-atomics-on-mips-clang.patch
+++ b/recipes-graphics/mesa/files/0001-meson-misdetects-64bit-atomics-on-mips-clang.patch
@@ -1,0 +1,27 @@
+From bb2f0bea553d51d659a9bc46f7ae186885405151 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 13 Jan 2020 15:23:47 -0800
+Subject: [PATCH] meson misdetects 64bit atomics on mips/clang
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/util/u_atomic.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/util/u_atomic.c b/src/util/u_atomic.c
+index e4bffa8..58e1ddd 100644
+--- a/src/util/u_atomic.c
++++ b/src/util/u_atomic.c
+@@ -21,7 +21,7 @@
+  * IN THE SOFTWARE.
+  */
+ 
+-#if defined(MISSING_64BIT_ATOMICS) && defined(HAVE_PTHREAD)
++#if !defined(__clang__) && defined(MISSING_64BIT_ATOMICS) && defined(HAVE_PTHREAD)
+ 
+ #include <stdint.h>
+ #include <pthread.h>
+-- 
+2.24.1
+

--- a/recipes-graphics/mesa/files/0001-meson.build-check-for-all-linux-host_os-combinations.patch
+++ b/recipes-graphics/mesa/files/0001-meson.build-check-for-all-linux-host_os-combinations.patch
@@ -1,0 +1,43 @@
+From 0d9ed002eff176b902da266d89829a9b0cb10946 Mon Sep 17 00:00:00 2001
+From: Alistair Francis <alistair@alistair23.me>
+Date: Thu, 14 Nov 2019 13:04:49 -0800
+Subject: [PATCH] meson.build: check for all linux host_os combinations
+
+Make sure that we are also looking for our host_os combinations like
+linux-musl etc. when assuming support for DRM/KMS.
+
+Also delete a duplicate line.
+
+Upstream-Status: Pending
+
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>
+Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
+Signed-off-by: Alistair Francis <alistair@alistair23.me>
+
+---
+ meson.build | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 898d025..09e3759 100644
+--- a/meson.build
++++ b/meson.build
+@@ -124,7 +124,7 @@ with_any_opengl = with_opengl or with_gles1 or with_gles2
+ # Only build shared_glapi if at least one OpenGL API is enabled
+ with_shared_glapi = with_shared_glapi and with_any_opengl
+ 
+-system_has_kms_drm = ['openbsd', 'netbsd', 'freebsd', 'gnu/kfreebsd', 'dragonfly', 'linux', 'sunos'].contains(host_machine.system())
++system_has_kms_drm = ['openbsd', 'netbsd', 'freebsd', 'dragonfly'].contains(host_machine.system()) or host_machine.system().startswith('linux')
+ 
+ dri_drivers = get_option('dri-drivers')
+ if dri_drivers.contains('auto')
+@@ -884,7 +884,7 @@ if cc.compiles('__uint128_t foo(void) { return 0; }',
+ endif
+ 
+ # TODO: this is very incomplete
+-if ['linux', 'cygwin', 'gnu', 'freebsd', 'gnu/kfreebsd'].contains(host_machine.system())
++if ['cygwin', 'gnu', 'gnu/kfreebsd'].contains(host_machine.system()) or host_machine.system().startswith('linux')
+   pre_args += '-D_GNU_SOURCE'
+ elif host_machine.system() == 'sunos'
+   pre_args += '-D__EXTENSIONS__'

--- a/recipes-graphics/mesa/files/0002-meson.build-make-TLS-ELF-optional.patch
+++ b/recipes-graphics/mesa/files/0002-meson.build-make-TLS-ELF-optional.patch
@@ -1,0 +1,46 @@
+From df835389699b32bb6610b39972502e323f8e09e5 Mon Sep 17 00:00:00 2001
+From: Alistair Francis <alistair@alistair23.me>
+Date: Thu, 14 Nov 2019 13:08:31 -0800
+Subject: [PATCH] meson.build: make TLS ELF optional
+
+USE_ELF_TLS has replaced GLX_USE_TLS so this patch is the original "make
+TLS GLX optional again" patch updated to the latest mesa.
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Alistair Francis <alistair@alistair23.me>
+
+---
+ meson.build       | 2 +-
+ meson_options.txt | 6 ++++++
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 09e3759..a954118 100644
+--- a/meson.build
++++ b/meson.build
+@@ -387,7 +387,7 @@ if with_egl and not (with_platform_drm or with_platform_surfaceless or with_plat
+ endif
+ 
+ # Android uses emutls for versions <= P/28. For USE_ELF_TLS we need ELF TLS.
+-if host_machine.system() != 'windows' and (not with_platform_android or get_option('platform-sdk-version') >= 29)
++if (not with_platform_android or get_option('platform-sdk-version') >= 29) and get_option('elf-tls')
+   pre_args += '-DUSE_ELF_TLS'
+ endif
+ 
+diff --git a/meson_options.txt b/meson_options.txt
+index 626baf3..637ff14 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -341,6 +341,12 @@ option(
+   value : true,
+   description : 'Enable direct rendering in GLX and EGL for DRI',
+ )
++option(
++  'elf-tls',
++  type : 'boolean',
++  value : true,
++  description : 'Enable TLS support in ELF',
++)
+ option(
+   'I-love-half-baked-turnips',
+   type : 'boolean',

--- a/recipes-graphics/mesa/files/0003-Allow-enable-DRI-without-DRI-drivers.patch
+++ b/recipes-graphics/mesa/files/0003-Allow-enable-DRI-without-DRI-drivers.patch
@@ -1,0 +1,46 @@
+From 7eaa21a79ce6d6e92f6bf98c28b68e3fcb4d7874 Mon Sep 17 00:00:00 2001
+From: Fabio Berton <fabio.berton@ossystems.com.br>
+Date: Wed, 12 Jun 2019 14:18:31 -0300
+Subject: [PATCH] Allow enable DRI without DRI drivers
+
+Upstream-Status: Pending
+
+Signed-off-by: Andrei Gherzan <andrei@gherzan.ro>
+Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>
+Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
+
+---
+ meson.build       | 2 +-
+ meson_options.txt | 6 ++++++
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index a954118..62864c6 100644
+--- a/meson.build
++++ b/meson.build
+@@ -154,7 +154,7 @@ with_dri_r200 = dri_drivers.contains('r200')
+ with_dri_nouveau = dri_drivers.contains('nouveau')
+ with_dri_swrast = dri_drivers.contains('swrast')
+ 
+-with_dri = dri_drivers.length() != 0 and dri_drivers != ['']
++with_dri = get_option('dri') or (dri_drivers.length() != 0 and dri_drivers != [''])
+ 
+ gallium_drivers = get_option('gallium-drivers')
+ if gallium_drivers.contains('auto')
+diff --git a/meson_options.txt b/meson_options.txt
+index 637ff14..700c34c 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -35,6 +35,12 @@ option(
+   choices : ['auto', 'true', 'false'],
+   description : 'enable support for dri3'
+ )
++option(
++  'dri',
++  type : 'boolean',
++  value : false,
++  description : 'enable support for dri'
++)
+ option(
+   'dri-drivers',
+   type : 'array',

--- a/recipes-graphics/mesa/files/0004-Revert-mesa-Enable-asm-unconditionally-now-that-gen_.patch
+++ b/recipes-graphics/mesa/files/0004-Revert-mesa-Enable-asm-unconditionally-now-that-gen_.patch
@@ -1,0 +1,147 @@
+From 41cd8836d785c79381764e7de59319f87959a5cf Mon Sep 17 00:00:00 2001
+From: Alistair Francis <alistair@alistair23.me>
+Date: Thu, 14 Nov 2019 09:06:02 -0800
+Subject: [PATCH] Revert "mesa: Enable asm unconditionally, now that
+ gen_matypes is gone."
+
+This reverts commit 20294dceebc23236e33b22578245f7e6f41b6997.
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Alistair Francis <alistair@alistair23.me>
+
+---
+ meson.build       | 94 ++++++++++++++++++++++++++++++-----------------
+ meson_options.txt |  6 +++
+ 2 files changed, 67 insertions(+), 33 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 62864c6..b53be8d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -49,6 +49,7 @@ with_vulkan_icd_dir = get_option('vulkan-icd-dir')
+ with_tests = get_option('build-tests')
+ with_valgrind = get_option('valgrind')
+ with_libunwind = get_option('libunwind')
++with_asm = get_option('asm')
+ with_glx_read_only_text = get_option('glx-read-only-text')
+ with_glx_direct = get_option('glx-direct')
+ with_osmesa = get_option('osmesa')
+@@ -1093,41 +1094,68 @@ dep_ws2_32 = cc.find_library('ws2_32', required : with_platform_windows)
+ 
+ # TODO: shared/static? Is this even worth doing?
+ 
++# When cross compiling we generally need to turn off the use of assembly,
++# because mesa's assembly relies on building an executable for the host system,
++# and running it to get information about struct sizes. There is at least one
++# case of cross compiling where we can use asm, and that's x86_64 -> x86 when
++# host OS == build OS, since in that case the build machine can run the host's
++# binaries.
++if with_asm and meson.is_cross_build()
++  if build_machine.system() != host_machine.system()
++    # TODO: It may be possible to do this with an exe_wrapper (like wine).
++    message('Cross compiling from one OS to another, disabling assembly.')
++    with_asm = false
++  elif not (build_machine.cpu_family().startswith('x86') and host_machine.cpu_family() == 'x86')
++    # FIXME: Gentoo always sets -m32 for x86_64 -> x86 builds, resulting in an
++    # x86 -> x86 cross compile. We use startswith rather than == to handle this
++    # case.
++    # TODO: There may be other cases where the 64 bit version of the
++    # architecture can run 32 bit binaries (aarch64 and armv7 for example)
++    message('''
++      Cross compiling to different architectures, and the host cannot run
++      the build machine's binaries. Disabling assembly.
++    ''')
++    with_asm = false
++  endif
++endif
++
+ with_asm_arch = ''
+-if host_machine.cpu_family() == 'x86'
+-  if system_has_kms_drm or host_machine.system() == 'gnu'
+-    with_asm_arch = 'x86'
+-    pre_args += ['-DUSE_X86_ASM', '-DUSE_MMX_ASM', '-DUSE_3DNOW_ASM',
+-                 '-DUSE_SSE_ASM']
+-
+-    if with_glx_read_only_text
+-      pre_args += ['-DGLX_X86_READONLY_TEXT']
++if with_asm
++  if host_machine.cpu_family() == 'x86'
++    if system_has_kms_drm or host_machine.system() == 'gnu'
++      with_asm_arch = 'x86'
++      pre_args += ['-DUSE_X86_ASM', '-DUSE_MMX_ASM', '-DUSE_3DNOW_ASM',
++                   '-DUSE_SSE_ASM']
++
++      if with_glx_read_only_text
++         pre_args += ['-DGLX_X86_READONLY_TEXT']
++      endif
++    endif
++  elif host_machine.cpu_family() == 'x86_64'
++    if system_has_kms_drm
++      with_asm_arch = 'x86_64'
++      pre_args += ['-DUSE_X86_64_ASM']
++    endif
++  elif host_machine.cpu_family() == 'arm'
++    if system_has_kms_drm
++      with_asm_arch = 'arm'
++      pre_args += ['-DUSE_ARM_ASM']
++    endif
++  elif host_machine.cpu_family() == 'aarch64'
++    if system_has_kms_drm
++      with_asm_arch = 'aarch64'
++      pre_args += ['-DUSE_AARCH64_ASM']
++    endif
++  elif host_machine.cpu_family() == 'sparc64'
++    if system_has_kms_drm
++      with_asm_arch = 'sparc'
++      pre_args += ['-DUSE_SPARC_ASM']
++    endif
++  elif host_machine.cpu_family().startswith('ppc64') and host_machine.endian() == 'little'
++    if system_has_kms_drm
++      with_asm_arch = 'ppc64le'
++      pre_args += ['-DUSE_PPC64LE_ASM']
+     endif
+-  endif
+-elif host_machine.cpu_family() == 'x86_64'
+-  if system_has_kms_drm
+-    with_asm_arch = 'x86_64'
+-    pre_args += ['-DUSE_X86_64_ASM']
+-  endif
+-elif host_machine.cpu_family() == 'arm'
+-  if system_has_kms_drm
+-    with_asm_arch = 'arm'
+-    pre_args += ['-DUSE_ARM_ASM']
+-  endif
+-elif host_machine.cpu_family() == 'aarch64'
+-  if system_has_kms_drm
+-    with_asm_arch = 'aarch64'
+-    pre_args += ['-DUSE_AARCH64_ASM']
+-  endif
+-elif host_machine.cpu_family() == 'sparc64'
+-  if system_has_kms_drm
+-    with_asm_arch = 'sparc'
+-    pre_args += ['-DUSE_SPARC_ASM']
+-  endif
+-elif host_machine.cpu_family().startswith('ppc64') and host_machine.endian() == 'little'
+-  if system_has_kms_drm
+-    with_asm_arch = 'ppc64le'
+-    pre_args += ['-DUSE_PPC64LE_ASM']
+   endif
+ endif
+ 
+diff --git a/meson_options.txt b/meson_options.txt
+index 700c34c..62e8472 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -241,6 +241,12 @@ option(
+   value : false,
+   description : 'Enable GLVND support.'
+ )
++option(
++  'asm',
++  type : 'boolean',
++  value : true,
++  description : 'Build assembly code if possible'
++)
+ option(
+    'glx-read-only-text',
+    type : 'boolean',

--- a/recipes-graphics/mesa/files/0005-vc4-use-intmax_t-for-formatted-output-of-timespec-me.patch
+++ b/recipes-graphics/mesa/files/0005-vc4-use-intmax_t-for-formatted-output-of-timespec-me.patch
@@ -1,0 +1,53 @@
+From 38a313474e127d61e749866423e708fc86ed9ec5 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 4 Dec 2019 14:15:28 -0800
+Subject: [PATCH] vc4: use intmax_t for formatted output of timespec members
+
+32bit architectures which have 64bit time_t does not fit the assumption
+of time_t being same as system long int
+
+Fixes
+error: format specifies type 'long' but the argument has type 'time_t' (aka 'long long') [-Werror,-Wformat]
+                        time.tv_sec);
+                        ^~~~~~~~~~~
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mesa/mesa/merge_requests/2966]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/gallium/drivers/v3d/v3d_bufmgr.c | 4 ++--
+ src/gallium/drivers/vc4/vc4_bufmgr.c | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/gallium/drivers/v3d/v3d_bufmgr.c b/src/gallium/drivers/v3d/v3d_bufmgr.c
+index b3e4d053cc0..c514bf00bf0 100644
+--- a/src/gallium/drivers/v3d/v3d_bufmgr.c
++++ b/src/gallium/drivers/v3d/v3d_bufmgr.c
+@@ -80,8 +80,8 @@ v3d_bo_dump_stats(struct v3d_screen *screen)
+ 
+                 struct timespec time;
+                 clock_gettime(CLOCK_MONOTONIC, &time);
+-                fprintf(stderr, "  now:               %ld\n",
+-                        time.tv_sec);
++                fprintf(stderr, "  now:               %jd\n",
++                        (intmax_t)time.tv_sec);
+         }
+ }
+ 
+diff --git a/src/gallium/drivers/vc4/vc4_bufmgr.c b/src/gallium/drivers/vc4/vc4_bufmgr.c
+index 5ec360934c0..bf05f6cadd6 100644
+--- a/src/gallium/drivers/vc4/vc4_bufmgr.c
++++ b/src/gallium/drivers/vc4/vc4_bufmgr.c
+@@ -107,8 +107,8 @@ vc4_bo_dump_stats(struct vc4_screen *screen)
+ 
+                 struct timespec time;
+                 clock_gettime(CLOCK_MONOTONIC, &time);
+-                fprintf(stderr, "  now:               %ld\n",
+-                        time.tv_sec);
++                fprintf(stderr, "  now:               %jd\n",
++                        (intmax_t)time.tv_sec);
+         }
+ }
+ 
+-- 
+2.24.0
+

--- a/recipes-graphics/mesa/libglu_9.0.1.bb
+++ b/recipes-graphics/mesa/libglu_9.0.1.bb
@@ -1,0 +1,30 @@
+SUMMARY = "The OpenGL utility toolkit"
+DESCRIPTION = "GLU is a utility toolkit used with OpenGL implementations"
+
+HOMEPAGE = "http://mesa3d.org"
+BUGTRACKER = "https://bugs.freedesktop.org"
+SECTION = "x11"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://include/GL/glu.h;endline=29;md5=6b79c570f644363b356456e7d44471d9 \
+                    file://src/libtess/tess.c;endline=29;md5=6b79c570f644363b356456e7d44471d9"
+
+# Epoch as this used to be part of mesa
+PE = "2"
+PR = "0"
+
+SRC_URI = "https://mesa.freedesktop.org/archive/glu/glu-${PV}.tar.gz"
+
+SRC_URI[md5sum] = "5599a0e0a97335e10239d9165aced60d"
+SRC_URI[sha256sum] = "f6f484cfcd51e489afe88031afdea1e173aa652697e4c19ddbcb8260579a10f7"
+
+S = "${WORKDIR}/glu-${PV}"
+
+DEPENDS = "virtual/libgl"
+
+inherit autotools pkgconfig features_check
+
+# Requires libGL.so which is provided by mesa when x11 in DISTRO_FEATURES
+REQUIRED_DISTRO_FEATURES = "x11 opengl"
+
+# Remove the mesa-glu dependency in mesa-glu-dev, as mesa-glu is empty
+RDEPENDS_${PN}-dev = ""

--- a/recipes-graphics/mesa/libglu_9.0.1.bb
+++ b/recipes-graphics/mesa/libglu_9.0.1.bb
@@ -21,7 +21,7 @@ S = "${WORKDIR}/glu-${PV}"
 
 DEPENDS = "virtual/libgl"
 
-inherit autotools pkgconfig features_check
+inherit autotools pkgconfig
 
 # Requires libGL.so which is provided by mesa when x11 in DISTRO_FEATURES
 REQUIRED_DISTRO_FEATURES = "x11 opengl"

--- a/recipes-graphics/mesa/mesa-demos/0001-mesa-demos-Add-missing-data-files.patch
+++ b/recipes-graphics/mesa/mesa-demos/0001-mesa-demos-Add-missing-data-files.patch
@@ -1,0 +1,624 @@
+From b695c3a3fa3f4cd48c13aa26542110de27075518 Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew_moseley@mentor.com>
+Date: Mon, 12 May 2014 15:22:32 -0400
+Subject: [PATCH 1/9] mesa-demos: Add missing data files.
+
+Add some data files that are present in the git repository:
+   http://cgit.freedesktop.org/mesa/demos/tree/?id=mesa-demos-8.1.0
+but not in the release tarball
+   ftp://ftp.freedesktop.org/pub/mesa/demos/8.1.0/mesa-demos-8.1.0.tar.bz2
+
+Upstream-Status: Backport
+Signed-off-by: Drew Moseley <drew_moseley@mentor.com>
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+ src/fpglsl/depth-read.glsl      |   4 +
+ src/fpglsl/infinite-loop.glsl   |   7 +
+ src/glsl/CH11-bumpmaptex.frag   |  47 +++++++
+ src/glsl/blinking-teapot.frag   |  31 +++++
+ src/glsl/blinking-teapot.vert   |  16 +++
+ src/glsl/convolution.frag       |  21 +++
+ src/glsl/simplex-noise.glsl     | 279 ++++++++++++++++++++++++++++++++++++++++
+ src/glsl/skinning.vert          |  24 ++++
+ src/perf/glslstateschange1.frag |  19 +++
+ src/perf/glslstateschange1.vert |  14 ++
+ src/perf/glslstateschange2.frag |  17 +++
+ src/perf/glslstateschange2.vert |  14 ++
+ src/vpglsl/infinite-loop.glsl   |   8 ++
+ 13 files changed, 501 insertions(+)
+ create mode 100644 src/fpglsl/depth-read.glsl
+ create mode 100644 src/fpglsl/infinite-loop.glsl
+ create mode 100644 src/glsl/CH11-bumpmaptex.frag
+ create mode 100644 src/glsl/blinking-teapot.frag
+ create mode 100644 src/glsl/blinking-teapot.vert
+ create mode 100644 src/glsl/convolution.frag
+ create mode 100644 src/glsl/simplex-noise.glsl
+ create mode 100644 src/glsl/skinning.vert
+ create mode 100644 src/perf/glslstateschange1.frag
+ create mode 100644 src/perf/glslstateschange1.vert
+ create mode 100644 src/perf/glslstateschange2.frag
+ create mode 100644 src/perf/glslstateschange2.vert
+ create mode 100644 src/vpglsl/infinite-loop.glsl
+
+diff --git a/src/fpglsl/depth-read.glsl b/src/fpglsl/depth-read.glsl
+new file mode 100644
+index 0000000..86d298e
+--- /dev/null
++++ b/src/fpglsl/depth-read.glsl
+@@ -0,0 +1,4 @@
++void main()
++{
++   gl_FragColor = gl_FragCoord.zzzz;
++}
+diff --git a/src/fpglsl/infinite-loop.glsl b/src/fpglsl/infinite-loop.glsl
+new file mode 100644
+index 0000000..c6dc6ee
+--- /dev/null
++++ b/src/fpglsl/infinite-loop.glsl
+@@ -0,0 +1,7 @@
++void main() {
++   vec4 sum = vec4(0);
++   for (int i = 1; i != 2; i += 2) {
++      sum += vec4(0.1, 0.1, 0.1, 0.1);
++   }
++   gl_FragColor = sum;
++}
+diff --git a/src/glsl/CH11-bumpmaptex.frag b/src/glsl/CH11-bumpmaptex.frag
+new file mode 100644
+index 0000000..b5dabb4
+--- /dev/null
++++ b/src/glsl/CH11-bumpmaptex.frag
+@@ -0,0 +1,47 @@
++//
++// Fragment shader for procedural bumps
++//
++// Authors: John Kessenich, Randi Rost
++//
++// Copyright (c) 2002-2006 3Dlabs Inc. Ltd. 
++//
++// See 3Dlabs-License.txt for license information
++//
++// Texture mapping/modulation added by Brian Paul
++//
++
++varying vec3 LightDir;
++varying vec3 EyeDir;
++
++uniform float BumpDensity;     // = 16.0
++uniform float BumpSize;        // = 0.15
++uniform float SpecularFactor;  // = 0.5
++
++uniform sampler2D Tex;
++
++void main()
++{
++    vec3 ambient = vec3(0.25);
++    vec3 litColor;
++    vec2 c = BumpDensity * gl_TexCoord[0].st;
++    vec2 p = fract(c) - vec2(0.5);
++
++    float d, f;
++    d = p.x * p.x + p.y * p.y;
++    f = inversesqrt(d + 1.0);
++
++    if (d >= BumpSize)
++        { p = vec2(0.0); f = 1.0; }
++
++    vec3 SurfaceColor = texture2D(Tex, gl_TexCoord[0].st).xyz;
++
++    vec3 normDelta = vec3(p.x, p.y, 1.0) * f;
++    litColor = SurfaceColor * (ambient + max(dot(normDelta, LightDir), 0.0));
++    vec3 reflectDir = reflect(LightDir, normDelta);
++    
++    float spec = max(dot(EyeDir, reflectDir), 0.0);
++    spec *= SpecularFactor;
++    litColor = min(litColor + spec, vec3(1.0));
++
++    gl_FragColor = vec4(litColor, 1.0);
++}
+diff --git a/src/glsl/blinking-teapot.frag b/src/glsl/blinking-teapot.frag
+new file mode 100644
+index 0000000..0db060b
+--- /dev/null
++++ b/src/glsl/blinking-teapot.frag
+@@ -0,0 +1,31 @@
++#extension GL_ARB_uniform_buffer_object : enable
++
++layout(std140) uniform colors0
++{
++    float DiffuseCool;
++    float DiffuseWarm;
++    vec3  SurfaceColor;
++    vec3  WarmColor;
++    vec3  CoolColor;
++    vec4  some[8];
++};
++
++varying float NdotL;
++varying vec3  ReflectVec;
++varying vec3  ViewVec;
++
++void main (void)
++{
++
++    vec3 kcool    = min(CoolColor + DiffuseCool * SurfaceColor, 1.0);
++    vec3 kwarm    = min(WarmColor + DiffuseWarm * SurfaceColor, 1.0);
++    vec3 kfinal   = mix(kcool, kwarm, NdotL);
++
++    vec3 nreflect = normalize(ReflectVec);
++    vec3 nview    = normalize(ViewVec);
++
++    float spec    = max(dot(nreflect, nview), 0.0);
++    spec          = pow(spec, 32.0);
++
++    gl_FragColor = vec4 (min(kfinal + spec, 1.0), 1.0);
++}
+diff --git a/src/glsl/blinking-teapot.vert b/src/glsl/blinking-teapot.vert
+new file mode 100644
+index 0000000..397d733
+--- /dev/null
++++ b/src/glsl/blinking-teapot.vert
+@@ -0,0 +1,16 @@
++vec3 LightPosition = vec3(0.0, 10.0, 4.0); 
++ 
++varying float NdotL;
++varying vec3  ReflectVec;
++varying vec3  ViewVec;
++ 
++void main(void)
++{
++    vec3 ecPos      = vec3 (gl_ModelViewMatrix * gl_Vertex);
++    vec3 tnorm      = normalize(gl_NormalMatrix * gl_Normal);
++    vec3 lightVec   = normalize(LightPosition - ecPos);
++    ReflectVec      = normalize(reflect(-lightVec, tnorm));
++    ViewVec         = normalize(-ecPos);
++    NdotL           = (dot(lightVec, tnorm) + 1.0) * 0.5;
++    gl_Position     = ftransform();
++}
+diff --git a/src/glsl/convolution.frag b/src/glsl/convolution.frag
+new file mode 100644
+index 0000000..e49b8ac
+--- /dev/null
++++ b/src/glsl/convolution.frag
+@@ -0,0 +1,21 @@
++
++const int KernelSize = 9;
++
++//texture offsets
++uniform vec2 Offset[KernelSize];
++//convolution kernel
++uniform vec4 KernelValue[KernelSize];
++uniform sampler2D srcTex;
++uniform vec4 ScaleFactor;
++uniform vec4 BaseColor;
++
++void main(void)
++{
++    int i;
++    vec4 sum = vec4(0.0);
++    for (i = 0; i < KernelSize; ++i) {
++        vec4 tmp = texture2D(srcTex, gl_TexCoord[0].st + Offset[i]);
++        sum += tmp * KernelValue[i];
++    }
++    gl_FragColor = sum * ScaleFactor + BaseColor;
++}
+diff --git a/src/glsl/simplex-noise.glsl b/src/glsl/simplex-noise.glsl
+new file mode 100644
+index 0000000..b6833cb
+--- /dev/null
++++ b/src/glsl/simplex-noise.glsl
+@@ -0,0 +1,279 @@
++//
++// Description : Array and textureless GLSL 2D/3D/4D simplex
++// noise functions.
++// Author : Ian McEwan, Ashima Arts.
++// Maintainer : ijm
++// Lastmod : 20110223
++// License : Copyright (C) 2011 Ashima Arts. All rights reserved.
++// Distributed under the Artistic License 2.0; See LICENCE file.
++//
++
++#define NORMALIZE_GRADIENTS
++#undef USE_CIRCLE
++#define COLLAPSE_SORTNET
++
++float permute(float x0,vec3 p) {
++  float x1 = mod(x0 * p.y, p.x);
++  return floor( mod( (x1 + p.z) *x0, p.x ));
++  }
++vec2 permute(vec2 x0,vec3 p) {
++  vec2 x1 = mod(x0 * p.y, p.x);
++  return floor( mod( (x1 + p.z) *x0, p.x ));
++  }
++vec3 permute(vec3 x0,vec3 p) {
++  vec3 x1 = mod(x0 * p.y, p.x);
++  return floor( mod( (x1 + p.z) *x0, p.x ));
++  }
++vec4 permute(vec4 x0,vec3 p) {
++  vec4 x1 = mod(x0 * p.y, p.x);
++  return floor( mod( (x1 + p.z) *x0, p.x ));
++  }
++
++uniform vec4 pParam;
++// Example
++// const vec4 pParam = vec4( 17.* 17., 34., 1., 7.);
++
++float taylorInvSqrt(float r)
++  {
++  return ( 0.83666002653408 + 0.7*0.85373472095314 - 0.85373472095314 * r );
++  }
++
++float simplexNoise2(vec2 v)
++  {
++  const vec2 C = vec2(0.211324865405187134, // (3.0-sqrt(3.0))/6.;
++                      0.366025403784438597); // 0.5*(sqrt(3.0)-1.);
++  const vec3 D = vec3( 0., 0.5, 2.0) * 3.14159265358979312;
++// First corner
++  vec2 i = floor(v + dot(v, C.yy) );
++  vec2 x0 = v - i + dot(i, C.xx);
++
++// Other corners
++  vec2 i1 = (x0.x > x0.y) ? vec2(1.,0.) : vec2(0.,1.) ;
++
++   // x0 = x0 - 0. + 0. * C
++  vec2 x1 = x0 - i1 + 1. * C.xx ;
++  vec2 x2 = x0 - 1. + 2. * C.xx ;
++
++// Permutations
++  i = mod(i, pParam.x);
++  vec3 p = permute( permute(
++             i.y + vec3(0., i1.y, 1. ), pParam.xyz)
++           + i.x + vec3(0., i1.x, 1. ), pParam.xyz);
++
++#ifndef USE_CIRCLE
++// ( N points uniformly over a line, mapped onto a diamond.)
++  vec3 x = fract(p / pParam.w) ;
++  vec3 h = 0.5 - abs(x) ;
++
++  vec3 sx = vec3(lessThan(x,D.xxx)) *2. -1.;
++  vec3 sh = vec3(lessThan(h,D.xxx));
++
++  vec3 a0 = x + sx*sh;
++  vec2 p0 = vec2(a0.x,h.x);
++  vec2 p1 = vec2(a0.y,h.y);
++  vec2 p2 = vec2(a0.z,h.z);
++
++#ifdef NORMALISE_GRADIENTS
++  p0 *= taylorInvSqrt(dot(p0,p0));
++  p1 *= taylorInvSqrt(dot(p1,p1));
++  p2 *= taylorInvSqrt(dot(p2,p2));
++#endif
++
++  vec3 g = 2.0 * vec3( dot(p0, x0), dot(p1, x1), dot(p2, x2) );
++#else
++// N points around a unit circle.
++  vec3 phi = D.z * mod(p,pParam.w) /pParam.w ;
++  vec4 a0 = sin(phi.xxyy+D.xyxy);
++  vec2 a1 = sin(phi.zz +D.xy);
++  vec3 g = vec3( dot(a0.xy, x0), dot(a0.zw, x1), dot(a1.xy, x2) );
++#endif
++// mix
++  vec3 m = max(0.5 - vec3(dot(x0,x0), dot(x1,x1), dot(x2,x2)), 0.);
++  m = m*m ;
++  return 1.66666* 70.*dot(m*m, g);
++  }
++
++float simplexNoise3(vec3 v)
++  {
++  const vec2 C = vec2(1./6. , 1./3. ) ;
++  const vec4 D = vec4(0., 0.5, 1.0, 2.0);
++
++// First corner
++  vec3 i = floor(v + dot(v, C.yyy) );
++  vec3 x0 = v - i + dot(i, C.xxx) ;
++  
++// Other corners
++#ifdef COLLAPSE_SORTNET
++  vec3 g = vec3( greaterThan( x0.xyz, x0.yzx) );
++  vec3 l = vec3( lessThanEqual( x0.xyz, x0.yzx) );
++
++  vec3 i1 = g.xyz * l.zxy;
++  vec3 i2 = max( g.xyz, l.zxy);
++#else
++// Keeping this clean - let the compiler optimize.
++  vec3 q1;
++  q1.x = max(x0.x, x0.y);
++  q1.y = min(x0.x, x0.y);
++  q1.z = x0.z;
++
++  vec3 q2;
++  q2.x = max(q1.x,q1.z);
++  q2.z = min(q1.x,q1.z);
++  q2.y = q1.y;
++
++  vec3 q3;
++  q3.y = max(q2.y, q2.z);
++  q3.z = min(q2.y, q2.z);
++  q3.x = q2.x;
++
++  vec3 i1 = vec3(equal(q3.xxx, x0));
++  vec3 i2 = i1 + vec3(equal(q3.yyy, x0));
++#endif
++
++   // x0 = x0 - 0. + 0. * C
++  vec3 x1 = x0 - i1 + 1. * C.xxx;
++  vec3 x2 = x0 - i2 + 2. * C.xxx;
++  vec3 x3 = x0 - 1. + 3. * C.xxx;
++
++// Permutations
++  i = mod(i, pParam.x );
++  vec4 p = permute( permute( permute(
++             i.z + vec4(0., i1.z, i2.z, 1. ), pParam.xyz)
++           + i.y + vec4(0., i1.y, i2.y, 1. ), pParam.xyz)
++           + i.x + vec4(0., i1.x, i2.x, 1. ), pParam.xyz);
++
++// Gradients
++// ( N*N points uniformly over a square, mapped onto a octohedron.)
++  float n_ = 1.0/pParam.w ;
++  vec3 ns = n_ * D.wyz - D.xzx ;
++
++  vec4 j = p - pParam.w*pParam.w*floor(p * ns.z *ns.z); // mod(p,N*N)
++
++  vec4 x_ = floor(j * ns.z) ;
++  vec4 y_ = floor(j - pParam.w * x_ ) ; // mod(j,N)
++
++  vec4 x = x_ *ns.x + ns.yyyy;
++  vec4 y = y_ *ns.x + ns.yyyy;
++  vec4 h = 1. - abs(x) - abs(y);
++
++  vec4 b0 = vec4( x.xy, y.xy );
++  vec4 b1 = vec4( x.zw, y.zw );
++
++  vec4 s0 = vec4(lessThan(b0,D.xxxx)) *2. -1.;
++  vec4 s1 = vec4(lessThan(b1,D.xxxx)) *2. -1.;
++  vec4 sh = vec4(lessThan(h, D.xxxx));
++
++  vec4 a0 = b0.xzyw + s0.xzyw*sh.xxyy ;
++  vec4 a1 = b1.xzyw + s1.xzyw*sh.zzww ;
++
++  vec3 p0 = vec3(a0.xy,h.x);
++  vec3 p1 = vec3(a0.zw,h.y);
++  vec3 p2 = vec3(a1.xy,h.z);
++  vec3 p3 = vec3(a1.zw,h.w);
++
++#ifdef NORMALISE_GRADIENTS
++  p0 *= taylorInvSqrt(dot(p0,p0));
++  p1 *= taylorInvSqrt(dot(p1,p1));
++  p2 *= taylorInvSqrt(dot(p2,p2));
++  p3 *= taylorInvSqrt(dot(p3,p3));
++#endif
++
++// Mix
++  vec4 m = max(0.6 - vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), 0.);
++  m = m * m;
++//used to be 64.
++  return 48.0 * dot( m*m, vec4( dot(p0,x0), dot(p1,x1),
++                                dot(p2,x2), dot(p3,x3) ) );
++  }
++
++vec4 grad4(float j, vec4 ip)
++  {
++  const vec4 ones = vec4(1.,1.,1.,-1.);
++  vec4 p,s;
++
++  p.xyz = floor( fract (vec3(j) * ip.xyz) *pParam.w) * ip.z -1.0;
++  p.w = 1.5 - dot(abs(p.xyz), ones.xyz);
++  s = vec4(lessThan(p,vec4(0.)));
++  p.xyz = p.xyz + (s.xyz*2.-1.) * s.www;
++
++  return p;
++  }
++
++float simplexNoise4(vec4 v)
++  {
++  const vec2 C = vec2( 0.138196601125010504, // (5 - sqrt(5))/20 G4
++                        0.309016994374947451); // (sqrt(5) - 1)/4 F4
++// First corner
++  vec4 i = floor(v + dot(v, C.yyyy) );
++  vec4 x0 = v - i + dot(i, C.xxxx);
++
++// Other corners
++
++// Force existance of strict total ordering in sort.
++  vec4 q0 = floor(x0 * 1024.0) + vec4( 0., 1./4., 2./4. , 3./4.);
++  vec4 q1;
++  q1.xy = max(q0.xy,q0.zw); // x:z y:w
++  q1.zw = min(q0.xy,q0.zw);
++
++  vec4 q2;
++  q2.xz = max(q1.xz,q1.yw); // x:y z:w
++  q2.yw = min(q1.xz,q1.yw);
++  
++  vec4 q3;
++  q3.y = max(q2.y,q2.z); // y:z
++  q3.z = min(q2.y,q2.z);
++  q3.xw = q2.xw;
++
++  vec4 i1 = vec4(lessThanEqual(q3.xxxx, q0));
++  vec4 i2 = vec4(lessThanEqual(q3.yyyy, q0));
++  vec4 i3 = vec4(lessThanEqual(q3.zzzz, q0));
++
++   // x0 = x0 - 0. + 0. * C
++  vec4 x1 = x0 - i1 + 1. * C.xxxx;
++  vec4 x2 = x0 - i2 + 2. * C.xxxx;
++  vec4 x3 = x0 - i3 + 3. * C.xxxx;
++  vec4 x4 = x0 - 1. + 4. * C.xxxx;
++
++// Permutations
++  i = mod(i, pParam.x );
++  float j0 = permute( permute( permute( permute (
++              i.w, pParam.xyz) + i.z, pParam.xyz)
++            + i.y, pParam.xyz) + i.x, pParam.xyz);
++  vec4 j1 = permute( permute( permute( permute (
++             i.w + vec4(i1.w, i2.w, i3.w, 1. ), pParam.xyz)
++           + i.z + vec4(i1.z, i2.z, i3.z, 1. ), pParam.xyz)
++           + i.y + vec4(i1.y, i2.y, i3.y, 1. ), pParam.xyz)
++           + i.x + vec4(i1.x, i2.x, i3.x, 1. ), pParam.xyz);
++// Gradients
++// ( N*N*N points uniformly over a cube, mapped onto a 4-octohedron.)
++  vec4 ip = pParam ;
++  ip.xy *= pParam.w ;
++  ip.x *= pParam.w ;
++  ip = vec4(1.,1.,1.,2.) / ip ;
++
++  vec4 p0 = grad4(j0, ip);
++  vec4 p1 = grad4(j1.x, ip);
++  vec4 p2 = grad4(j1.y, ip);
++  vec4 p3 = grad4(j1.z, ip);
++  vec4 p4 = grad4(j1.w, ip);
++
++#ifdef NORMALISE_GRADIENTS
++  p0 *= taylorInvSqrt(dot(p0,p0));
++  p1 *= taylorInvSqrt(dot(p1,p1));
++  p2 *= taylorInvSqrt(dot(p2,p2));
++  p3 *= taylorInvSqrt(dot(p3,p3));
++  p4 *= taylorInvSqrt(dot(p4,p4));
++#endif
++
++// Mix
++  vec3 m0 = max(0.6 - vec3(dot(x0,x0), dot(x1,x1), dot(x2,x2)), 0.);
++  vec2 m1 = max(0.6 - vec2(dot(x3,x3), dot(x4,x4) ), 0.);
++  m0 = m0 * m0;
++  m1 = m1 * m1;
++  return 32. * ( dot(m0*m0, vec3( dot( p0, x0 ), dot( p1, x1 ), dot( p2, x2 )))
++               + dot(m1*m1, vec2( dot( p3, x3 ), dot( p4, x4 ) ) ) ) ;
++
++  }
++
++
++
+diff --git a/src/glsl/skinning.vert b/src/glsl/skinning.vert
+new file mode 100644
+index 0000000..28970ee
+--- /dev/null
++++ b/src/glsl/skinning.vert
+@@ -0,0 +1,24 @@
++// Vertex weighting/blendin shader
++// Brian Paul
++// 4 Nov 2008
++
++uniform mat4 mat0, mat1;
++attribute float weight;
++
++void main() 
++{
++   // simple diffuse shading
++   // Note that we should really transform the normal vector along with
++   // the postion below... someday.
++   vec3 lightVec = vec3(0, 0, 1);
++   vec3 norm = gl_NormalMatrix * gl_Normal;
++   float dot = 0.2 + max(0.0, dot(norm, lightVec));
++   gl_FrontColor = vec4(dot);
++
++   // compute sum of weighted transformations
++   vec4 pos0 = mat0 * gl_Vertex;
++   vec4 pos1 = mat1 * gl_Vertex;
++   vec4 pos = mix(pos0, pos1, weight);
++
++   gl_Position = gl_ModelViewProjectionMatrix * pos;
++}
+diff --git a/src/perf/glslstateschange1.frag b/src/perf/glslstateschange1.frag
+new file mode 100644
+index 0000000..0839436
+--- /dev/null
++++ b/src/perf/glslstateschange1.frag
+@@ -0,0 +1,19 @@
++// Multi-texture fragment shader
++// Brian Paul
++
++// Composite second texture over first.
++// We're assuming the 2nd texture has a meaningful alpha channel.
++
++uniform sampler2D tex1;
++uniform sampler2D tex2;
++uniform vec4 UniV1;
++uniform vec4 UniV2;
++
++void main()
++{
++   vec4 t3;
++   vec4 t1 = texture2D(tex1, gl_TexCoord[0].xy);
++   vec4 t2 = texture2D(tex2, gl_TexCoord[1].xy);
++   t3 = mix(t1, t2, t2.w);
++   gl_FragColor = t3 + UniV1 + UniV2;
++}
+diff --git a/src/perf/glslstateschange1.vert b/src/perf/glslstateschange1.vert
+new file mode 100644
+index 0000000..cef50db
+--- /dev/null
++++ b/src/perf/glslstateschange1.vert
+@@ -0,0 +1,14 @@
++// Multi-texture vertex shader
++// Brian Paul
++
++
++attribute vec4 TexCoord0, TexCoord1;
++attribute vec4 VertCoord;
++
++void main()
++{
++   gl_TexCoord[0] = TexCoord0;
++   gl_TexCoord[1] = TexCoord1;
++   // note: may use gl_Vertex or VertCoord here for testing:
++   gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
++}
+diff --git a/src/perf/glslstateschange2.frag b/src/perf/glslstateschange2.frag
+new file mode 100644
+index 0000000..0df0319
+--- /dev/null
++++ b/src/perf/glslstateschange2.frag
+@@ -0,0 +1,17 @@
++// Multi-texture fragment shader
++// Brian Paul
++
++// Composite second texture over first.
++// We're assuming the 2nd texture has a meaningful alpha channel.
++
++uniform sampler2D tex1;
++uniform sampler2D tex2;
++uniform vec4 UniV1;
++uniform vec4 UniV2;
++
++void main()
++{
++   vec4 t1 = texture2D(tex1, gl_TexCoord[0].xy);
++   vec4 t2 = texture2D(tex2, gl_TexCoord[1].xy);
++   gl_FragColor = t1 + t2 + UniV1 + UniV2;
++}
+diff --git a/src/perf/glslstateschange2.vert b/src/perf/glslstateschange2.vert
+new file mode 100644
+index 0000000..cef50db
+--- /dev/null
++++ b/src/perf/glslstateschange2.vert
+@@ -0,0 +1,14 @@
++// Multi-texture vertex shader
++// Brian Paul
++
++
++attribute vec4 TexCoord0, TexCoord1;
++attribute vec4 VertCoord;
++
++void main()
++{
++   gl_TexCoord[0] = TexCoord0;
++   gl_TexCoord[1] = TexCoord1;
++   // note: may use gl_Vertex or VertCoord here for testing:
++   gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
++}
+diff --git a/src/vpglsl/infinite-loop.glsl b/src/vpglsl/infinite-loop.glsl
+new file mode 100644
+index 0000000..bc7ae4b
+--- /dev/null
++++ b/src/vpglsl/infinite-loop.glsl
+@@ -0,0 +1,8 @@
++void main() {
++   gl_Position = gl_Vertex;
++   vec4 sum = vec4(0);
++   for (int i = 1; i != 2; i += 2) {
++      sum += vec4(0.1, 0.1, 0.1, 0.1);
++   }
++   gl_FrontColor = sum;
++}
+-- 
+2.0.0
+

--- a/recipes-graphics/mesa/mesa-demos/0003-configure-Allow-to-disable-demos-which-require-GLEW-.patch
+++ b/recipes-graphics/mesa/mesa-demos/0003-configure-Allow-to-disable-demos-which-require-GLEW-.patch
@@ -1,0 +1,377 @@
+From 779438770bedf3d53e6ad8f7cd6889b7f50daf3b Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Wed, 9 Jul 2014 14:23:41 +0200
+Subject: [PATCH] configure: Allow to disable demos which require GLEW or GLU
+
+* in some systems without X11 support we don't have GLEW, but
+  mesa-demos are still useful
+
+Upstream-Status: Pending
+
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+
+Port to 8.3.0
+Signed-off-by: Jussi Kukkonen <jussi.kukkonen@intel.com>
+---
+ configure.ac                  | 49 ++++++++++++++++++++---------
+ src/Makefile.am               | 18 ++++++++---
+ src/demos/Makefile.am         | 73 ++++++++++++++++++++++++-------------------
+ src/egl/Makefile.am           |  8 +++--
+ src/egl/opengles1/Makefile.am | 10 ++++--
+ src/egl/opengles2/Makefile.am | 29 ++++++++---------
+ 6 files changed, 117 insertions(+), 70 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 0525b09..28834cd 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -93,25 +93,44 @@ AC_EGREP_HEADER([glutInitContextProfile],
+ 		[AC_DEFINE(HAVE_FREEGLUT)],
+ 		[])
+ 
+-dnl Check for GLEW
+-PKG_CHECK_MODULES(GLEW, [glew >= 1.5.4])
+-DEMO_CFLAGS="$DEMO_CFLAGS $GLEW_CFLAGS"
+-DEMO_LIBS="$DEMO_LIBS $GLEW_LIBS"
++AC_ARG_ENABLE([glew],
++    [AS_HELP_STRING([--enable-glew],
++        [build demos which require glew @<:@default=yes@:>@])],
++    [enable_glew="$enableval"],
++    [enable_glew=yes]
++)
++
++if test "x$enable_glew" = xyes; then
++    dnl Check for GLEW
++    PKG_CHECK_MODULES(GLEW, [glew >= 1.5.4], [glew_enabled=yes], [glew_enabled=no])
++    DEMO_CFLAGS="$DEMO_CFLAGS $GLEW_CFLAGS"
++    DEMO_LIBS="$DEMO_LIBS $GLEW_LIBS"
++fi
+ 
+ # LIBS was set by AC_CHECK_LIB above
+ LIBS=""
+ 
+-PKG_CHECK_MODULES(GLU, [glu], [],
+-		  [AC_CHECK_HEADER([GL/glu.h],
+-				   [],
+-		  		   AC_MSG_ERROR([GLU not found]))
+-		   AC_CHECK_LIB([GLU],
+-				[gluBeginCurve],
+-				[GLU_LIBS=-lGLU],
+-				AC_MSG_ERROR([GLU required])) ])
++AC_ARG_ENABLE([glu],
++    [AS_HELP_STRING([--enable-glu],
++        [build demos which require glu @<:@default=yes@:>@])],
++    [enable_glu="$enableval"],
++    [enable_glu=yes]
++)
+ 
+-DEMO_CFLAGS="$DEMO_CFLAGS $GLU_CFLAGS"
+-DEMO_LIBS="$DEMO_LIBS $GLU_LIBS"
++if test "x$enable_glu" = xyes; then
++    PKG_CHECK_MODULES(GLU, [glu], [glu_enabled=yes],
++                     [AC_CHECK_HEADER([GL/glu.h],
++                                      [],
++                                      AC_MSG_ERROR([GLU not found]))
++                      AC_CHECK_LIB([GLU],
++                                   [gluBeginCurve],
++                                   [GLU_LIBS=-lGLU
++				    glu_enabled=yes],
++                                   AC_MSG_ERROR([GLU required])) ])
++
++    DEMO_CFLAGS="$DEMO_CFLAGS $GLU_CFLAGS"
++    DEMO_LIBS="$DEMO_LIBS $GLU_LIBS"
++fi
+ 
+ AC_ARG_ENABLE([egl],
+     [AS_HELP_STRING([--enable-egl],
+@@ -304,6 +323,8 @@ AC_SUBST([WAYLAND_CFLAGS])
+ AC_SUBST([WAYLAND_LIBS])
+ 
+ 
++AM_CONDITIONAL(HAVE_GLU, test "x$glu_enabled" = "xyes")
++AM_CONDITIONAL(HAVE_GLEW, test "x$glew_enabled" = "xyes")
+ AM_CONDITIONAL(HAVE_EGL, test "x$egl_enabled" = "xyes")
+ AM_CONDITIONAL(HAVE_GLESV1, test "x$glesv1_enabled" = "xyes")
+ AM_CONDITIONAL(HAVE_GLESV2, test "x$glesv2_enabled" = "xyes")
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 1647d64..8b89dee 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -22,15 +22,19 @@
+ # Authors:
+ #    Eric Anholt <eric@anholt.net>
+ 
++if HAVE_GLEW
++UTIL = util
++endif
++
+ SUBDIRS = \
+-	util \
++	$(UTIL) \
+ 	data \
+ 	demos \
+ 	egl \
+ 	fp \
+ 	fpglsl \
+ 	glsl \
+-        gs \
++	gs \
+ 	objviewer \
+ 	osdemos \
+ 	perf \
+@@ -40,8 +44,12 @@ SUBDIRS = \
+ 	slang \
+ 	tests \
+ 	tools \
+-	trivial \
+-	vp \
+-	vpglsl \
+ 	wgl \
+ 	xdemos
++
++if HAVE_GLEW
++SUBDIRS += \
++	vp \
++	vpglsl \
++	trivial
++endif
+diff --git a/src/demos/Makefile.am b/src/demos/Makefile.am
+index 41603fa..ab1e3ab 100644
+--- a/src/demos/Makefile.am
++++ b/src/demos/Makefile.am
+@@ -30,91 +30,100 @@ AM_LDFLAGS = \
+ 	$(DEMO_LIBS) \
+ 	$(GLUT_LIBS)
+ 
++bin_PROGRAMS =
++
+ if HAVE_GLUT
+-bin_PROGRAMS = \
++if HAVE_GLEW
++bin_PROGRAMS += \
+ 	arbfplight \
+ 	arbfslight \
+ 	arbocclude \
+ 	arbocclude2 \
+-	bounce \
+-	clearspd \
+ 	copypix \
+ 	cubemap \
+ 	cuberender \
+ 	dinoshade \
+-	dissolve \
+-	drawpix \
+ 	engine \
+ 	fbo_firecube \
+ 	fbotexture \
+-	fire \
+ 	fogcoord \
+ 	fplight \
+ 	fslight \
++	gloss \
++	isosurf \
++	multiarb \
++	paltex \
++	pointblast \
++	projtex \
++	shadowtex \
++	spriteblast \
++	stex3d \
++	textures \
++	vao_demo \
++	winpos
++
++copypix_LDADD = ../util/libutil.la
++cubemap_LDADD = ../util/libutil.la
++cuberender_LDADD = ../util/libutil.la
++engine_LDADD = ../util/libutil.la
++fbo_firecube_LDADD = ../util/libutil.la
++gloss_LDADD = ../util/libutil.la
++isosurf_LDADD = ../util/libutil.la
++multiarb_LDADD = ../util/libutil.la
++projtex_LDADD = ../util/libutil.la
++textures_LDADD = ../util/libutil.la
++winpos_LDADD = ../util/libutil.la
++endif
++
++if HAVE_GLU
++bin_PROGRAMS += \
++	bounce \
++	clearspd \
++	dissolve \
++	drawpix \
++	fire \
+ 	gamma \
+ 	gearbox \
+ 	gears \
+ 	geartrain \
+ 	glinfo \
+-	gloss \
+ 	gltestperf \
+ 	ipers \
+-	isosurf \
+ 	lodbias \
+ 	morph3d \
+-	multiarb \
+-	paltex \
+ 	pixeltest \
+-	pointblast \
+-	projtex \
+ 	ray \
+ 	readpix \
+ 	reflect \
+ 	renormal \
+-	shadowtex \
+ 	singlebuffer \
+ 	spectex \
+-	spriteblast \
+-	stex3d \
+ 	teapot \
+ 	terrain \
+ 	tessdemo \
+ 	texcyl \
+ 	texenv \
+-	textures \
+ 	trispd \
+ 	tunnel2 \
+-	tunnel \
+-	vao_demo \
+-	winpos
+-endif
++	tunnel
+ 
+ tunnel_SOURCES = \
+ 	tunnel.c \
+ 	tunneldat.h
+ 
+-copypix_LDADD = ../util/libutil.la
+-cubemap_LDADD = ../util/libutil.la
+-cuberender_LDADD = ../util/libutil.la
+-drawpix_LDADD = ../util/libutil.la
+ dissolve_LDADD = ../util/libutil.la
+-engine_LDADD = ../util/libutil.la
+-fbo_firecube_LDADD = ../util/libutil.la
++drawpix_LDADD = ../util/libutil.la
+ fire_LDADD = ../util/libutil.la
+-gloss_LDADD = ../util/libutil.la
+ ipers_LDADD = ../util/libutil.la
+-isosurf_LDADD = ../util/libutil.la
+ lodbias_LDADD = ../util/libutil.la
+-multiarb_LDADD = ../util/libutil.la
+-projtex_LDADD = ../util/libutil.la
+ readpix_LDADD = ../util/libutil.la
+ reflect_LDADD = ../util/libutil.la
+ teapot_LDADD = ../util/libutil.la
+ texcyl_LDADD = ../util/libutil.la
+-textures_LDADD = ../util/libutil.la
+ tunnel_LDADD = ../util/libutil.la
+ tunnel2_LDADD = ../util/libutil.la
+-winpos_LDADD = ../util/libutil.la
++endif
++endif
+ 
+ EXTRA_DIST = \
+ 	README
+diff --git a/src/egl/Makefile.am b/src/egl/Makefile.am
+index d64a49e..4fe1ca8 100644
+--- a/src/egl/Makefile.am
++++ b/src/egl/Makefile.am
+@@ -24,8 +24,12 @@
+ 
+ SUBDIRS = \
+ 	eglut \
+-	opengl \
+-	openvg \
+ 	opengles1 \
+ 	opengles2 \
+ 	oes_vg
++
++if HAVE_GLU
++SUBDIRS += \
++	opengl \
++	openvg
++endif
+diff --git a/src/egl/opengles1/Makefile.am b/src/egl/opengles1/Makefile.am
+index fa397c2..21853e8 100644
+--- a/src/egl/opengles1/Makefile.am
++++ b/src/egl/opengles1/Makefile.am
+@@ -36,9 +36,12 @@ AM_LDFLAGS = \
+ 	$(EGL_LIBS) \
+ 	-lm
+ 
++noinst_PROGRAMS =
++
+ if HAVE_EGL
+ if HAVE_GLESV1
+-noinst_PROGRAMS = \
++if HAVE_X11
++bin_PROGRAMS = \
+ 	bindtex \
+ 	clear \
+ 	drawtex_x11 \
+@@ -52,8 +55,6 @@ noinst_PROGRAMS = \
+ 	torus_x11 \
+ 	tri_x11 \
+ 	two_win
+-endif
+-endif
+ 
+ bindtex_LDADD = $(X11_LIBS)
+ es1_info_LDADD = $(X11_LIBS)
+@@ -76,3 +77,6 @@ drawtex_x11_LDADD = ../eglut/libeglut_x11.la
+ gears_x11_LDADD = ../eglut/libeglut_x11.la
+ torus_x11_LDADD = ../eglut/libeglut_x11.la
+ tri_x11_LDADD = ../eglut/libeglut_x11.la
++endif
++endif
++endif
+diff --git a/src/egl/opengles2/Makefile.am b/src/egl/opengles2/Makefile.am
+index b80ba50..17f8d49 100644
+--- a/src/egl/opengles2/Makefile.am
++++ b/src/egl/opengles2/Makefile.am
+@@ -33,27 +33,28 @@ AM_LDFLAGS = \
+ 	$(EGL_LIBS) \
+ 	-lm
+ 
++bin_PROGRAMS =
++
+ if HAVE_EGL
+ if HAVE_GLESV2
+-bin_PROGRAMS =
+-if HAVE_X11
+-bin_PROGRAMS += \
+-	es2_info \
+-	es2gears_x11 \
+-	es2tri
+-endif
+ if HAVE_WAYLAND
+ bin_PROGRAMS += es2gears_wayland
+-endif
+-endif
++
++es2gears_wayland_SOURCES = es2gears.c
++es2gears_wayland_LDADD = ../eglut/libeglut_wayland.la
+ endif
+ 
+-es2_info_LDADD = $(X11_LIBS)
+-es2tri_LDADD = $(X11_LIBS)
++if HAVE_X11
++bin_PROGRAMS += \
++	es2tri \
++	es2_info \
++	es2gears_x11
+ 
++es2_info_LDADD = $(X11_LIBS)
+ es2gears_x11_SOURCES = es2gears.c
+-
+ es2gears_x11_LDADD = ../eglut/libeglut_x11.la
++es2tri_LDADD = $(X11_LIBS)
++endif
++endif
++endif
+ 
+-es2gears_wayland_SOURCES = es2gears.c
+-es2gears_wayland_LDADD = ../eglut/libeglut_wayland.la
+-- 
+2.1.4
+

--- a/recipes-graphics/mesa/mesa-demos/0004-Use-DEMOS_DATA_DIR-to-locate-data-files.patch
+++ b/recipes-graphics/mesa/mesa-demos/0004-Use-DEMOS_DATA_DIR-to-locate-data-files.patch
@@ -1,0 +1,234 @@
+From 5e10108d76a59abac21c7e540bcfd2ddaccca2cb Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew_moseley@mentor.com>
+Date: Fri, 9 May 2014 11:50:24 -0400
+Subject: [PATCH 4/9] Use DEMOS_DATA_DIR to locate data files
+
+Upstream-Status: Submitted [https://bugs.freedesktop.org/show_bug.cgi?id=78496]
+Signed-off-by: Drew Moseley <drew_moseley@mentor.com>
+---
+ src/glsl/bezier.c           |  2 +-
+ src/glsl/blinking-teapot.c  |  4 ++--
+ src/glsl/brick.c            |  4 ++--
+ src/glsl/bump.c             |  6 +++---
+ src/glsl/convolutions.c     |  2 +-
+ src/glsl/mandelbrot.c       |  4 ++--
+ src/glsl/multitex.c         |  4 ++--
+ src/glsl/simplex-noise.c    |  2 +-
+ src/glsl/skinning.c         |  4 ++--
+ src/glsl/texdemo1.c         |  8 ++++----
+ src/glsl/toyball.c          |  4 ++--
+ src/objviewer/objview.c     | 12 ++++++------
+ src/perf/glslstateschange.c |  8 ++++----
+ 13 files changed, 32 insertions(+), 32 deletions(-)
+
+diff --git a/src/glsl/bezier.c b/src/glsl/bezier.c
+index 0b56bc1..e01603d 100644
+--- a/src/glsl/bezier.c
++++ b/src/glsl/bezier.c
+@@ -13,7 +13,7 @@
+ #include "glut_wrap.h"
+ #include "shaderutil.h"
+ 
+-static const char *filename = "bezier.geom";
++static const char *filename = DEMOS_DATA_DIR "bezier.geom";
+ 
+ static GLuint fragShader;
+ static GLuint vertShader;
+diff --git a/src/glsl/blinking-teapot.c b/src/glsl/blinking-teapot.c
+index e3bf24d..7662b1f 100644
+--- a/src/glsl/blinking-teapot.c
++++ b/src/glsl/blinking-teapot.c
+@@ -63,8 +63,8 @@ init_opengl (void)
+      exit(1);
+   }     
+ 
+-  vshad_id = CompileShaderFile (GL_VERTEX_SHADER, "blinking-teapot.vert");
+-  fshad_id = CompileShaderFile (GL_FRAGMENT_SHADER, "blinking-teapot.frag");
++  vshad_id = CompileShaderFile (GL_VERTEX_SHADER, DEMOS_DATA_DIR "blinking-teapot.vert");
++  fshad_id = CompileShaderFile (GL_FRAGMENT_SHADER, DEMOS_DATA_DIR "blinking-teapot.frag");
+   prog_id = LinkShaders (vshad_id, fshad_id);
+ 
+   UseProgram (prog_id);
+diff --git a/src/glsl/brick.c b/src/glsl/brick.c
+index 3021856..fe5f190 100644
+--- a/src/glsl/brick.c
++++ b/src/glsl/brick.c
+@@ -14,8 +14,8 @@
+ #include "shaderutil.h"
+ 
+ 
+-static char *FragProgFile = "CH06-brick.frag";
+-static char *VertProgFile = "CH06-brick.vert";
++static char *FragProgFile = DEMOS_DATA_DIR "CH06-brick.frag";
++static char *VertProgFile = DEMOS_DATA_DIR "CH06-brick.vert";
+ 
+ /* program/shader objects */
+ static GLuint fragShader;
+diff --git a/src/glsl/bump.c b/src/glsl/bump.c
+index 59f62cd..3a1b20a 100644
+--- a/src/glsl/bump.c
++++ b/src/glsl/bump.c
+@@ -15,9 +15,9 @@
+ #include "readtex.h"
+ 
+ 
+-static char *FragProgFile = "CH11-bumpmap.frag";
+-static char *FragTexProgFile = "CH11-bumpmaptex.frag";
+-static char *VertProgFile = "CH11-bumpmap.vert";
++static char *FragProgFile = DEMOS_DATA_DIR "CH11-bumpmap.frag";
++static char *FragTexProgFile = DEMOS_DATA_DIR "CH11-bumpmaptex.frag";
++static char *VertProgFile = DEMOS_DATA_DIR "CH11-bumpmap.vert";
+ static char *TextureFile = DEMOS_DATA_DIR "tile.rgb";
+ 
+ /* program/shader objects */
+diff --git a/src/glsl/convolutions.c b/src/glsl/convolutions.c
+index a120cfe..9312f00 100644
+--- a/src/glsl/convolutions.c
++++ b/src/glsl/convolutions.c
+@@ -340,7 +340,7 @@ static void init(void)
+ 
+    menuInit();
+    readTexture(textureLocation);
+-   createProgram("convolution.vert", "convolution.frag");
++   createProgram(DEMOS_DATA_DIR "convolution.vert", DEMOS_DATA_DIR "convolution.frag");
+ 
+    glEnable(GL_TEXTURE_2D);
+    glClearColor(1.0, 1.0, 1.0, 1.0);
+diff --git a/src/glsl/mandelbrot.c b/src/glsl/mandelbrot.c
+index 31ede1d..ab34a0f 100644
+--- a/src/glsl/mandelbrot.c
++++ b/src/glsl/mandelbrot.c
+@@ -14,8 +14,8 @@
+ #include "shaderutil.h"
+ 
+ 
+-static char *FragProgFile = "CH18-mandel.frag";
+-static char *VertProgFile = "CH18-mandel.vert";
++static char *FragProgFile = DEMOS_DATA_DIR "CH18-mandel.frag";
++static char *VertProgFile = DEMOS_DATA_DIR "CH18-mandel.vert";
+ 
+ /* program/shader objects */
+ static GLuint fragShader;
+diff --git a/src/glsl/multitex.c b/src/glsl/multitex.c
+index 262ea50..546bd27 100644
+--- a/src/glsl/multitex.c
++++ b/src/glsl/multitex.c
+@@ -35,8 +35,8 @@
+ 
+ static const char *Demo = "multitex";
+ 
+-static const char *VertFile = "multitex.vert";
+-static const char *FragFile = "multitex.frag";
++static const char *VertFile = DEMOS_DATA_DIR "multitex.vert";
++static const char *FragFile = DEMOS_DATA_DIR "multitex.frag";
+ 
+ static const char *TexFiles[2] = 
+    {
+diff --git a/src/glsl/simplex-noise.c b/src/glsl/simplex-noise.c
+index 13fdd5d..885f01e 100644
+--- a/src/glsl/simplex-noise.c
++++ b/src/glsl/simplex-noise.c
+@@ -169,7 +169,7 @@ SpecialKey(int key, int x, int y)
+ static void
+ Init(void)
+ {
+-   const char *filename = "simplex-noise.glsl";
++   const char *filename = DEMOS_DATA_DIR "simplex-noise.glsl";
+    char noiseText[10000];
+    FILE *f;
+    int len;
+diff --git a/src/glsl/skinning.c b/src/glsl/skinning.c
+index bf38d77..536d475 100644
+--- a/src/glsl/skinning.c
++++ b/src/glsl/skinning.c
+@@ -20,8 +20,8 @@
+ #define M_PI 3.1415926535
+ #endif
+ 
+-static char *FragProgFile = "skinning.frag";
+-static char *VertProgFile = "skinning.vert";
++static char *FragProgFile = DEMOS_DATA_DIR "skinning.frag";
++static char *VertProgFile = DEMOS_DATA_DIR "skinning.vert";
+ 
+ /* program/shader objects */
+ static GLuint fragShader;
+diff --git a/src/glsl/texdemo1.c b/src/glsl/texdemo1.c
+index 6cde239..a082342 100644
+--- a/src/glsl/texdemo1.c
++++ b/src/glsl/texdemo1.c
+@@ -35,11 +35,11 @@
+ 
+ static const char *Demo = "texdemo1";
+ 
+-static const char *ReflectVertFile = "reflect.vert";
+-static const char *CubeFragFile = "cubemap.frag";
++static const char *ReflectVertFile = DEMOS_DATA_DIR "reflect.vert";
++static const char *CubeFragFile = DEMOS_DATA_DIR "cubemap.frag";
+ 
+-static const char *SimpleVertFile = "simple.vert";
+-static const char *SimpleTexFragFile = "shadowtex.frag";
++static const char *SimpleVertFile = DEMOS_DATA_DIR "simple.vert";
++static const char *SimpleTexFragFile = DEMOS_DATA_DIR "shadowtex.frag";
+ 
+ static const char *GroundImage = DEMOS_DATA_DIR "tile.rgb";
+ 
+diff --git a/src/glsl/toyball.c b/src/glsl/toyball.c
+index 5f27951..4e7e832 100644
+--- a/src/glsl/toyball.c
++++ b/src/glsl/toyball.c
+@@ -14,8 +14,8 @@
+ #include "shaderutil.h"
+ 
+ 
+-static char *FragProgFile = "CH11-toyball.frag";
+-static char *VertProgFile = "CH11-toyball.vert";
++static char *FragProgFile = DEMOS_DATA_DIR "CH11-toyball.frag";
++static char *VertProgFile = DEMOS_DATA_DIR "CH11-toyball.vert";
+ 
+ /* program/shader objects */
+ static GLuint fragShader;
+diff --git a/src/objviewer/objview.c b/src/objviewer/objview.c
+index 6def726..78a6acf 100644
+--- a/src/objviewer/objview.c
++++ b/src/objviewer/objview.c
+@@ -162,12 +162,12 @@ init_model(void)
+ static void
+ init_skybox(void)
+ {
+-   SkyboxTex = LoadSkyBoxCubeTexture("alpine_east.rgb",
+-                                     "alpine_west.rgb",
+-                                     "alpine_up.rgb",
+-                                     "alpine_down.rgb",
+-                                     "alpine_south.rgb",
+-                                     "alpine_north.rgb");
++   SkyboxTex = LoadSkyBoxCubeTexture(DEMOS_DATA_DIR "alpine_east.rgb",
++                                     DEMOS_DATA_DIR "alpine_west.rgb",
++                                     DEMOS_DATA_DIR "alpine_up.rgb",
++                                     DEMOS_DATA_DIR "alpine_down.rgb",
++                                     DEMOS_DATA_DIR "alpine_south.rgb",
++                                     DEMOS_DATA_DIR "alpine_north.rgb");
+    glmSpecularTexture(Model, SkyboxTex);
+ }
+ 
+diff --git a/src/perf/glslstateschange.c b/src/perf/glslstateschange.c
+index 7422b78..dbf8332 100644
+--- a/src/perf/glslstateschange.c
++++ b/src/perf/glslstateschange.c
+@@ -33,10 +33,10 @@
+ #include "glmain.h"
+ #include "common.h"
+ 
+-static const char *VertFile1 = "glslstateschange1.vert";
+-static const char *FragFile1 = "glslstateschange1.frag";
+-static const char *VertFile2 = "glslstateschange2.vert";
+-static const char *FragFile2 = "glslstateschange2.frag";
++static const char *VertFile1 = DEMOS_DATA_DIR "glslstateschange1.vert";
++static const char *FragFile1 = DEMOS_DATA_DIR "glslstateschange1.frag";
++static const char *VertFile2 = DEMOS_DATA_DIR "glslstateschange2.vert";
++static const char *FragFile2 = DEMOS_DATA_DIR "glslstateschange2.frag";
+ static struct uniform_info Uniforms1[] = {
+    { "tex1",  1, GL_SAMPLER_2D, { 0, 0, 0, 0 }, -1 },
+    { "tex2",  1, GL_SAMPLER_2D, { 1, 0, 0, 0 }, -1 },
+-- 
+2.0.0
+

--- a/recipes-graphics/mesa/mesa-demos/0007-Install-few-more-test-programs.patch
+++ b/recipes-graphics/mesa/mesa-demos/0007-Install-few-more-test-programs.patch
@@ -1,0 +1,43 @@
+From 2e0367a941445a862ab99c54ec85d1357d0f73c0 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Thu, 10 Jul 2014 14:30:52 +0200
+Subject: [PATCH] Install few more test programs
+
+Upstream-Status: Pending
+
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+
+Signed-off-by: Jussi Kukkonen <jussi.kukkonen@intel.com>
+
+---
+ src/egl/opengl/Makefile.am | 3 +--
+ src/egl/openvg/Makefile.am | 2 +-
+ 2 files changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/egl/opengl/Makefile.am b/src/egl/opengl/Makefile.am
+index 6d184ff6..ab09d028 100644
+--- a/src/egl/opengl/Makefile.am
++++ b/src/egl/opengl/Makefile.am
+@@ -57,8 +57,7 @@ endif
+ 
+ if HAVE_EGL
+ bin_PROGRAMS = \
+-	eglinfo
+-noinst_PROGRAMS = \
++	eglinfo \
+ 	peglgears \
+ 	$(EGL_DRM_DEMOS) \
+ 	$(EGL_X11_DEMOS) \
+diff --git a/src/egl/openvg/Makefile.am b/src/egl/openvg/Makefile.am
+index b0f1212f..5fd1cf83 100644
+--- a/src/egl/openvg/Makefile.am
++++ b/src/egl/openvg/Makefile.am
+@@ -49,7 +49,7 @@ endif
+ 
+ if HAVE_EGL
+ if HAVE_VG
+-noinst_PROGRAMS = \
++bin_PROGRAMS = \
+ 	$(EGL_X11_DEMOS)
+ endif
+ endif

--- a/recipes-graphics/mesa/mesa-demos/0008-glsl-perf-Add-few-missing-.glsl-.vert-.frag-files-to.patch
+++ b/recipes-graphics/mesa/mesa-demos/0008-glsl-perf-Add-few-missing-.glsl-.vert-.frag-files-to.patch
@@ -1,0 +1,99 @@
+From 894add34c2b5e6b4ccc78996bf681d7ec7bc9e36 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Thu, 10 Jul 2014 14:29:27 +0200
+Subject: [PATCH] glsl, perf: Add few missing .glsl, .vert, .frag files to
+ EXTRA_DATA
+
+Upstream-Status: Pending
+
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+
+---
+ src/fpglsl/Makefile.am |  2 ++
+ src/glsl/Makefile.am   | 10 ++++++++--
+ src/perf/Makefile.am   |  6 ++++++
+ src/vpglsl/Makefile.am |  1 +
+ 4 files changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/src/fpglsl/Makefile.am b/src/fpglsl/Makefile.am
+index 47c1039f..fd43c919 100644
+--- a/src/fpglsl/Makefile.am
++++ b/src/fpglsl/Makefile.am
+@@ -39,10 +39,12 @@ noinst_PROGRAMS = \
+ endif
+ 
+ EXTRA_DIST = \
++	depth-read.glsl \
+ 	dowhile2.glsl \
+ 	dowhile.glsl \
+ 	forbreak.glsl \
+ 	for.glsl \
++	infinite-loop.glsl \
+ 	mov.glsl \
+ 	mov-imm.glsl \
+ 	simpleif.glsl \
+diff --git a/src/glsl/Makefile.am b/src/glsl/Makefile.am
+index 4faa8dbf..079a29d8 100644
+--- a/src/glsl/Makefile.am
++++ b/src/glsl/Makefile.am
+@@ -37,7 +37,7 @@ AM_LDFLAGS = \
+ if HAVE_GLUT
+ bin_PROGRAMS = \
+ 	array \
+-        bezier \
++	bezier \
+ 	bitmap \
+ 	brick \
+ 	bump \
+@@ -123,12 +123,16 @@ EXTRA_DIST = \
+ 	CH06-brick.vert \
+ 	CH11-bumpmap.frag \
+ 	CH11-bumpmap.vert \
++	CH11-bumpmaptex.frag \
+ 	CH11-toyball.frag \
+ 	CH11-toyball.vert \
+ 	CH18-mandel.frag \
+ 	CH18-mandel.vert \
+-        bezier.geom \
++	bezier.geom \
+ 	brick.shtest \
++	blinking-teapot.frag \
++	blinking-teapot.vert \
++	convolution.frag \
+ 	convolution.vert \
+ 	cubemap.frag \
+ 	mandelbrot.shtest \
+@@ -138,5 +142,7 @@ EXTRA_DIST = \
+ 	reflect.vert \
+ 	shadowtex.frag \
+ 	simple.vert \
++	simplex-noise.glsl \
+ 	skinning.frag \
++	skinning.vert \
+ 	toyball.shtest
+diff --git a/src/perf/Makefile.am b/src/perf/Makefile.am
+index f0031fea..60069396 100644
+--- a/src/perf/Makefile.am
++++ b/src/perf/Makefile.am
+@@ -59,3 +59,9 @@ endif
+ 
+ glslstateschange_LDADD = libperf.la ../util/libutil.la
+ glsl_compile_time_LDADD = ../util/libutil.la
++
++EXTRA_DIST = \
++	glslstateschange1.frag \
++	glslstateschange1.vert \
++	glslstateschange2.frag \
++	glslstateschange2.vert
+diff --git a/src/vpglsl/Makefile.am b/src/vpglsl/Makefile.am
+index 4a85ed40..48b08f48 100644
+--- a/src/vpglsl/Makefile.am
++++ b/src/vpglsl/Makefile.am
+@@ -44,6 +44,7 @@ EXTRA_DIST = \
+ 	func2.glsl \
+ 	ifelse.glsl \
+ 	if.glsl \
++	infinite-loop.glsl \
+ 	mov.glsl \
+ 	nestedifs.glsl \
+ 	nestedswizzle.glsl \

--- a/recipes-graphics/mesa/mesa-demos/0009-glsl-perf-Install-.glsl-.vert-.frag-files.patch
+++ b/recipes-graphics/mesa/mesa-demos/0009-glsl-perf-Install-.glsl-.vert-.frag-files.patch
@@ -1,0 +1,71 @@
+From 477ab6d90a17d8e4d3935be6ce8b8e154db0e3e5 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Thu, 10 Jul 2014 14:48:12 +0200
+Subject: [PATCH] glsl, perf: Install .glsl, .vert, .frag files
+
+Upstream-Status: Pending
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+
+---
+ src/fpglsl/Makefile.am | 3 ++-
+ src/glsl/Makefile.am   | 3 ++-
+ src/perf/Makefile.am   | 3 ++-
+ src/vpglsl/Makefile.am | 3 ++-
+ 4 files changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/src/fpglsl/Makefile.am b/src/fpglsl/Makefile.am
+index fd43c919..2bf51de4 100644
+--- a/src/fpglsl/Makefile.am
++++ b/src/fpglsl/Makefile.am
+@@ -38,7 +38,8 @@ noinst_PROGRAMS = \
+ 	fp-tri
+ endif
+ 
+-EXTRA_DIST = \
++demosdatadir=$(datadir)/$(PACKAGE)/
++dist_demosdata_DATA= \
+ 	depth-read.glsl \
+ 	dowhile2.glsl \
+ 	dowhile.glsl \
+diff --git a/src/glsl/Makefile.am b/src/glsl/Makefile.am
+index 079a29d8..f66ec299 100644
+--- a/src/glsl/Makefile.am
++++ b/src/glsl/Makefile.am
+@@ -118,7 +118,8 @@ vert_or_frag_only_LDADD = ../util/libutil.la
+ vert_tex_LDADD = ../util/libutil.la
+ vsraytrace_LDADD = ../util/libutil.la
+ 
+-EXTRA_DIST = \
++demosdatadir=$(datadir)/$(PACKAGE)/
++dist_demosdata_DATA= \
+ 	CH06-brick.frag \
+ 	CH06-brick.vert \
+ 	CH11-bumpmap.frag \
+diff --git a/src/perf/Makefile.am b/src/perf/Makefile.am
+index 60069396..469bdf45 100644
+--- a/src/perf/Makefile.am
++++ b/src/perf/Makefile.am
+@@ -60,7 +60,8 @@ endif
+ glslstateschange_LDADD = libperf.la ../util/libutil.la
+ glsl_compile_time_LDADD = ../util/libutil.la
+ 
+-EXTRA_DIST = \
++demosdatadir=$(datadir)/$(PACKAGE)/
++dist_demosdata_DATA= \
+ 	glslstateschange1.frag \
+ 	glslstateschange1.vert \
+ 	glslstateschange2.frag \
+diff --git a/src/vpglsl/Makefile.am b/src/vpglsl/Makefile.am
+index 48b08f48..55268675 100644
+--- a/src/vpglsl/Makefile.am
++++ b/src/vpglsl/Makefile.am
+@@ -38,7 +38,8 @@ noinst_PROGRAMS = \
+ 	vp-tris
+ endif
+ 
+-EXTRA_DIST = \
++demosdatadir=$(datadir)/$(PACKAGE)/
++dist_demosdata_DATA= \
+ 	for.glsl \
+ 	func.glsl \
+ 	func2.glsl \

--- a/recipes-graphics/mesa/mesa-demos/0012-mesa-demos-OpenVG-demos-with-single-frame-need-eglSw.patch
+++ b/recipes-graphics/mesa/mesa-demos/0012-mesa-demos-OpenVG-demos-with-single-frame-need-eglSw.patch
@@ -1,0 +1,44 @@
+From 3aa84c47e88a4c38446ce1323abf6f2c77389104 Mon Sep 17 00:00:00 2001
+From: Prabhu <prabhu.sundararaj@freescale.com>
+Date: Mon, 16 Nov 2015 17:09:32 -0600
+Subject: [PATCH] mesa-demos: OpenVG demos with single frame need eglSwapBuffer
+
+sp and text demos rendering single frame. to display the
+single frame rendered needed a eglSwapBuffer to diplay to window.
+Hence added eglutPostRedisplay to display the frame
+
+Upstream-Status: Pending
+
+Signed-off-by: Prabhu <prabhu.sundararaj@freescale.com>
+---
+ src/egl/openvg/sp.c   | 1 +
+ src/egl/openvg/text.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/egl/openvg/sp.c b/src/egl/openvg/sp.c
+index a20c0a3..468e91e 100644
+--- a/src/egl/openvg/sp.c
++++ b/src/egl/openvg/sp.c
+@@ -500,6 +500,7 @@ draw(void)
+    }
+ 
+    vgFlush();
++   eglutPostRedisplay();
+ }
+ 
+ 
+diff --git a/src/egl/openvg/text.c b/src/egl/openvg/text.c
+index f5c6de8..492581c 100644
+--- a/src/egl/openvg/text.c
++++ b/src/egl/openvg/text.c
+@@ -360,6 +360,7 @@ display(void)
+ {
+    vgClear(0, 0, width, height);
+    glyph_string_draw(10.0, 10.0);
++   eglutPostRedisplay();
+ }
+ 
+ 
+-- 
+2.5.1
+

--- a/recipes-graphics/mesa/mesa-demos/0013-only-build-GLX-demos-if-needed.patch
+++ b/recipes-graphics/mesa/mesa-demos/0013-only-build-GLX-demos-if-needed.patch
@@ -1,0 +1,62 @@
+From 322af294390a7f4e1524c5a79312be6cbebce988 Mon Sep 17 00:00:00 2001
+From: Awais Belal <awais_belal@mentor.com>
+Date: Wed, 11 Nov 2015 17:22:12 +0500
+Subject: [PATCH] only build GLX demos if needed
+
+There are platforms that default to EGL only configurations
+in which case the GLX applications are not required
+at all. Allow the user to control generation of these
+demos as needed through a configure switch.
+
+Signed-off-by: Awais Belal <awais_belal@mentor.com>
+Upstream-Status: Pending
+---
+ configure.ac    | 9 +++++++++
+ src/Makefile.am | 6 +++++-
+ 2 files changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index f8ec7e3..1a4d96d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -132,6 +132,11 @@ if test "x$enable_glu" = xyes; then
+     DEMO_LIBS="$DEMO_LIBS $GLU_LIBS"
+ fi
+ 
++AC_ARG_ENABLE([glx-demos],
++    [AS_HELP_STRING([--enable-glx-demos],
++        [enable GLX demos @<:@default=auto@:>@])],
++    [glx_demos_enabled="$enableval"],
++    [glx_demos_enabled=yes])
+ AC_ARG_ENABLE([egl],
+     [AS_HELP_STRING([--enable-egl],
+         [enable EGL library @<:@default=auto@:>@])],
+@@ -325,6 +333,7 @@ AC_SUBST([WAYLAND_LIBS])
+ 
+ AM_CONDITIONAL(HAVE_GLU, test "x$glu_enabled" = "xyes")
+ AM_CONDITIONAL(HAVE_GLEW, test "x$glew_enabled" = "xyes")
++AM_CONDITIONAL(HAVE_GLX, test "x$glx_demos_enabled" = "xyes")
+ AM_CONDITIONAL(HAVE_EGL, test "x$egl_enabled" = "xyes")
+ AM_CONDITIONAL(HAVE_GLESV1, test "x$glesv1_enabled" = "xyes")
+ AM_CONDITIONAL(HAVE_GLESV2, test "x$glesv2_enabled" = "xyes")
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 8b89dee..a4d7e8f 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -44,8 +44,12 @@ SUBDIRS = \
+ 	slang \
+ 	tests \
+ 	tools \
+-	wgl \
++	wgl
++
++if HAVE_GLX
++SUBDIRS += \
+ 	xdemos
++endif
+ 
+ if HAVE_GLEW
+ SUBDIRS += \
+-- 
+1.9.1
+

--- a/recipes-graphics/mesa/mesa-demos_8.4.0.bb
+++ b/recipes-graphics/mesa/mesa-demos_8.4.0.bb
@@ -1,0 +1,59 @@
+SUMMARY = "Mesa demo applications"
+DESCRIPTION = "This package includes the demonstration application, such as glxgears. \
+These applications can be used for Mesa validation and benchmarking."
+HOMEPAGE = "http://mesa3d.org"
+BUGTRACKER = "https://bugs.freedesktop.org"
+SECTION = "x11"
+
+LICENSE = "MIT & PD"
+LIC_FILES_CHKSUM = "file://src/xdemos/glxgears.c;beginline=1;endline=20;md5=914225785450eff644a86c871d3ae00e \
+                    file://src/xdemos/glxdemo.c;beginline=1;endline=8;md5=b01d5ab1aee94d35b7efaa2ef48e1a06"
+
+SRC_URI = "https://mesa.freedesktop.org/archive/demos/${BPN}-${PV}.tar.bz2 \
+           file://0001-mesa-demos-Add-missing-data-files.patch \
+           file://0003-configure-Allow-to-disable-demos-which-require-GLEW-.patch \
+           file://0004-Use-DEMOS_DATA_DIR-to-locate-data-files.patch \
+           file://0007-Install-few-more-test-programs.patch \
+           file://0008-glsl-perf-Add-few-missing-.glsl-.vert-.frag-files-to.patch \
+           file://0009-glsl-perf-Install-.glsl-.vert-.frag-files.patch \
+           file://0012-mesa-demos-OpenVG-demos-with-single-frame-need-eglSw.patch \
+           file://0013-only-build-GLX-demos-if-needed.patch \
+           "
+SRC_URI[md5sum] = "6b65a02622765522176d00f553086fa3"
+SRC_URI[sha256sum] = "01e99c94a0184e63e796728af89bfac559795fb2a0d6f506fa900455ca5fff7d"
+
+inherit autotools pkgconfig features_check
+# depends on virtual/egl, virtual/libgl ...
+REQUIRED_DISTRO_FEATURES = "opengl x11"
+
+PACKAGECONFIG ?= "drm osmesa freetype2 gbm egl gles1 gles2 \
+                  x11 glew glu glx"
+
+# The Wayland code doesn't work with Wayland 1.0, so disable it for now
+#${@bb.utils.filter('DISTRO_FEATURES', 'wayland', d)}"
+
+EXTRA_OECONF = "--with-system-data-files"
+
+PACKAGECONFIG[drm] = "--enable-libdrm,--disable-libdrm,libdrm"
+PACKAGECONFIG[egl] = "--enable-egl,--disable-egl,virtual/egl"
+PACKAGECONFIG[freetype2] = "--enable-freetype2,--disable-freetype2,freetype"
+PACKAGECONFIG[gbm] = "--enable-gbm,--disable-gbm,virtual/libgl"
+PACKAGECONFIG[gles1] = "--enable-gles1,--disable-gles1,virtual/libgles1"
+PACKAGECONFIG[gles2] = "--enable-gles2,--disable-gles2,virtual/libgles2"
+PACKAGECONFIG[glut] = "--with-glut=${STAGING_EXECPREFIXDIR},--without-glut,freeglut"
+PACKAGECONFIG[osmesa] = "--enable-osmesa,--disable-osmesa,"
+PACKAGECONFIG[vg] = "--enable-vg,--disable-vg,virtual/libopenvg"
+PACKAGECONFIG[wayland] = "--enable-wayland,--disable-wayland,virtual/libgl wayland"
+PACKAGECONFIG[x11] = "--enable-x11,--disable-x11,virtual/libx11"
+PACKAGECONFIG[glew] = "--enable-glew,--disable-glew,glew"
+PACKAGECONFIG[glu] = "--enable-glu,--disable-glu,virtual/libgl"
+PACKAGECONFIG[glx] = "--enable-glx-demos,--disable-glx-demos"
+
+do_install_append() {
+	# it can be completely empty when all PACKAGECONFIG options are disabled
+	rmdir --ignore-fail-on-non-empty ${D}${bindir}
+
+	if [ -f ${D}${bindir}/clear ]; then
+        	mv ${D}${bindir}/clear ${D}${bindir}/clear.mesa-demos
+	fi
+}

--- a/recipes-graphics/mesa/mesa-demos_8.4.0.bb
+++ b/recipes-graphics/mesa/mesa-demos_8.4.0.bb
@@ -22,7 +22,7 @@ SRC_URI = "https://mesa.freedesktop.org/archive/demos/${BPN}-${PV}.tar.bz2 \
 SRC_URI[md5sum] = "6b65a02622765522176d00f553086fa3"
 SRC_URI[sha256sum] = "01e99c94a0184e63e796728af89bfac559795fb2a0d6f506fa900455ca5fff7d"
 
-inherit autotools pkgconfig features_check
+inherit autotools pkgconfig
 # depends on virtual/egl, virtual/libgl ...
 REQUIRED_DISTRO_FEATURES = "opengl x11"
 

--- a/recipes-graphics/mesa/mesa-gl_19.3.4.bb
+++ b/recipes-graphics/mesa/mesa-gl_19.3.4.bb
@@ -1,0 +1,10 @@
+require mesa_${PV}.bb
+
+SUMMARY += " (OpenGL only, no EGL/GLES)"
+
+PROVIDES = "virtual/libgl virtual/mesa"
+
+S = "${WORKDIR}/mesa-${PV}"
+
+PACKAGECONFIG ??= "opengl dri ${@bb.utils.filter('DISTRO_FEATURES', 'x11', d)}"
+PACKAGECONFIG_class-target = "opengl dri ${@bb.utils.filter('DISTRO_FEATURES', 'x11', d)}"

--- a/recipes-graphics/mesa/mesa-gl_20.0.0.bb
+++ b/recipes-graphics/mesa/mesa-gl_20.0.0.bb
@@ -1,0 +1,10 @@
+require mesa_${PV}.bb
+
+SUMMARY += " (OpenGL only, no EGL/GLES)"
+
+PROVIDES = "virtual/libgl virtual/mesa"
+
+S = "${WORKDIR}/mesa-${PV}"
+
+PACKAGECONFIG ??= "opengl dri ${@bb.utils.filter('DISTRO_FEATURES', 'x11', d)}"
+PACKAGECONFIG_class-target = "opengl dri ${@bb.utils.filter('DISTRO_FEATURES', 'x11', d)}"

--- a/recipes-graphics/mesa/mesa.inc
+++ b/recipes-graphics/mesa/mesa.inc
@@ -24,7 +24,7 @@ PROVIDES = " \
     virtual/mesa \
     "
 
-inherit meson pkgconfig python3native gettext features_check
+inherit meson pkgconfig python3native gettext
 
 # Unset these to stop python trying to report the target Python setup
 _PYTHON_SYSCONFIGDATA_NAME[unexport] = "1"

--- a/recipes-graphics/mesa/mesa.inc
+++ b/recipes-graphics/mesa/mesa.inc
@@ -1,0 +1,283 @@
+SUMMARY = "A free implementation of the OpenGL API"
+DESCRIPTION = "Mesa is an open-source implementation of the OpenGL specification - \
+a system for rendering interactive 3D graphics.  \
+A variety of device drivers allows Mesa to be used in many different environments \
+ranging from software emulation to complete hardware acceleration for modern GPUs. \
+Mesa is used as part of the overall Direct Rendering Infrastructure and X.org \
+environment."
+
+HOMEPAGE = "http://mesa3d.org"
+BUGTRACKER = "https://bugs.freedesktop.org"
+SECTION = "x11"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://docs/license.html;md5=3a4999caf82cc503ac8b9e37c235782e"
+
+PE = "2"
+
+DEPENDS = "expat makedepend-native flex-native bison-native libxml2-native zlib chrpath-replacement-native python3-mako-native gettext-native"
+EXTRANATIVEPATH += "chrpath-native"
+PROVIDES = " \
+    ${@bb.utils.contains('PACKAGECONFIG', 'opengl', 'virtual/libgl', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'gles', 'virtual/libgles1 virtual/libgles2', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'egl', 'virtual/egl', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'gbm', 'virtual/libgbm', '', d)} \
+    virtual/mesa \
+    "
+
+inherit meson pkgconfig python3native gettext features_check
+
+# Unset these to stop python trying to report the target Python setup
+_PYTHON_SYSCONFIGDATA_NAME[unexport] = "1"
+STAGING_INCDIR[unexport] = "1"
+STAGING_LIBDIR[unexport] = "1"
+
+BBCLASSEXTEND = "native nativesdk"
+
+ANY_OF_DISTRO_FEATURES_class-target = "opengl vulkan"
+
+PLATFORMS ??= "${@bb.utils.filter('PACKAGECONFIG', 'x11 wayland', d)} \
+               ${@bb.utils.contains('PACKAGECONFIG', 'gbm', 'drm', '', d)} \
+               surfaceless"
+
+export YOCTO_ALTERNATE_EXE_PATH = "${STAGING_LIBDIR}/llvm${MESA_LLVM_RELEASE}/llvm-config"
+export YOCTO_ALTERNATE_MULTILIB_NAME = "${base_libdir}"
+export LLVM_CONFIG = "${STAGING_BINDIR_NATIVE}/llvm-config${MESA_LLVM_RELEASE}"
+export WANT_LLVM_RELEASE = "${MESA_LLVM_RELEASE}"
+
+MESA_LLVM_RELEASE ?= "${LLVMVERSION}"
+
+# set the MESA_BUILD_TYPE to either 'release' (default) or 'debug'
+# by default the upstream mesa sources build a debug release
+# here we assume the user will want a release build by default
+MESA_BUILD_TYPE ?= "release"
+def check_buildtype(d):
+    _buildtype = d.getVar('MESA_BUILD_TYPE')
+    if _buildtype not in ['release', 'debug']:
+        bb.fatal("unknown build type (%s), please set MESA_BUILD_TYPE to either 'release' or 'debug'" % _buildtype)
+    if _buildtype == 'debug':
+        return 'debugoptimized'
+    return 'plain'
+MESON_BUILDTYPE = "${@check_buildtype(d)}"
+
+EXTRA_OEMESON = " \
+    -Dshared-glapi=true \
+    -Dgallium-opencl=disabled \
+    -Dglx-read-only-text=true \
+    -Dplatforms='${@",".join("${PLATFORMS}".split())}' \
+"
+
+PACKAGECONFIG_class-target ??= "${@bb.utils.filter('DISTRO_FEATURES', 'wayland vulkan', d)} \
+                   ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'opengl egl gles gbm dri gallium virgl', '', d)} \
+                   ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11 dri3', '', d)} \
+                   ${@bb.utils.contains('DISTRO_FEATURES', 'x11 vulkan', 'dri3', '', d)} \
+                   elf-tls \
+		   "
+PACKAGECONFIG_class-native ?= "gbm dri egl opengl elf-tls"
+PACKAGECONFIG_class-nativesdk ?= "gbm dri egl opengl elf-tls"
+
+PACKAGECONFIG_remove_libc-musl = "elf-tls"
+
+# "gbm" requires "dri", "opengl"
+PACKAGECONFIG[gbm] = "-Dgbm=true,-Dgbm=false"
+
+X11_DEPS = "xorgproto virtual/libx11 libxext libxxf86vm libxdamage libxfixes xrandr"
+# "x11" requires "opengl"
+PACKAGECONFIG[x11] = ",-Dglx=disabled,${X11_DEPS}"
+PACKAGECONFIG[elf-tls] = "-Delf-tls=true, -Delf-tls=false"
+PACKAGECONFIG[xvmc] = "-Dgallium-xvmc=true,-Dgallium-xvmc=false,libxvmc"
+PACKAGECONFIG[wayland] = ",,wayland-native wayland libdrm wayland-protocols"
+
+DRIDRIVERS_class-native = "swrast"
+DRIDRIVERS_class-nativesdk = "swrast"
+DRIDRIVERS_append_x86_class-target = ",r100,r200,nouveau,i965,i915"
+DRIDRIVERS_append_x86-64_class-target = ",r100,r200,nouveau,i965,i915"
+# "dri" requires "opengl"
+PACKAGECONFIG[dri] = "-Ddri=true -Ddri-drivers=${DRIDRIVERS}, -Ddri=false -Ddri-drivers='', xorgproto libdrm"
+PACKAGECONFIG[dri3] = "-Ddri3=true, -Ddri3=false, xorgproto libxshmfence"
+
+# Vulkan drivers need dri3 enabled
+# radeon could be enabled as well but requires gallium-llvm with llvm >= 3.9
+VULKAN_DRIVERS = ""
+VULKAN_DRIVERS_append_x86_class-target = ",intel"
+VULKAN_DRIVERS_append_x86-64_class-target = ",intel"
+PACKAGECONFIG[vulkan] = "-Dvulkan-drivers=${VULKAN_DRIVERS}, -Dvulkan-drivers='',"
+
+PACKAGECONFIG[opengl] = "-Dopengl=true, -Dopengl=false"
+
+# "gles" requires "opengl"
+PACKAGECONFIG[gles] = "-Dgles1=true -Dgles2=true, -Dgles1=false -Dgles2=false"
+
+# "egl" requires "dri", "opengl"
+PACKAGECONFIG[egl] = "-Degl=true, -Degl=false"
+
+PACKAGECONFIG[etnaviv] = ""
+PACKAGECONFIG[freedreno] = ""
+PACKAGECONFIG[kmsro] = ""
+PACKAGECONFIG[vc4] = ""
+PACKAGECONFIG[v3d] = ""
+
+GALLIUMDRIVERS = "swrast"
+# gallium swrast was found to crash Xorg on startup in x32 qemu
+GALLIUMDRIVERS_x86-x32 = ""
+
+GALLIUMDRIVERS_append ="${@bb.utils.contains('PACKAGECONFIG', 'etnaviv', ',etnaviv', '', d)}"
+GALLIUMDRIVERS_append ="${@bb.utils.contains('PACKAGECONFIG', 'freedreno', ',freedreno', '', d)}"
+GALLIUMDRIVERS_append ="${@bb.utils.contains('PACKAGECONFIG', 'kmsro', ',kmsro', '', d)}"
+GALLIUMDRIVERS_append ="${@bb.utils.contains('PACKAGECONFIG', 'vc4', ',vc4', '', d)}"
+GALLIUMDRIVERS_append ="${@bb.utils.contains('PACKAGECONFIG', 'v3d', ',v3d', '', d)}"
+
+# radeonsi requires LLVM
+GALLIUMDRIVERS_LLVM33 = "${@bb.utils.contains('PACKAGECONFIG', 'r600', ',radeonsi', '', d)}"
+GALLIUMDRIVERS_LLVM33_ENABLED = "${@oe.utils.version_less_or_equal('MESA_LLVM_RELEASE', '3.2', False, len('${GALLIUMDRIVERS_LLVM33}') > 0, d)}"
+GALLIUMDRIVERS_LLVM = "r300,svga,nouveau${@',${GALLIUMDRIVERS_LLVM33}' if ${GALLIUMDRIVERS_LLVM33_ENABLED} else ''}"
+
+PACKAGECONFIG[r600] = ""
+PACKAGECONFIG[virgl] = ""
+
+GALLIUMDRIVERS_append = "${@bb.utils.contains('PACKAGECONFIG', 'gallium-llvm', ',${GALLIUMDRIVERS_LLVM}', '', d)}"
+GALLIUMDRIVERS_append = "${@bb.utils.contains('PACKAGECONFIG', 'r600', ',r600', '', d)}"
+GALLIUMDRIVERS_append = "${@bb.utils.contains('PACKAGECONFIG', 'virgl', ',virgl', '', d)}"
+
+PACKAGECONFIG[gallium] = "-Dgallium-drivers=${GALLIUMDRIVERS}, -Dgallium-drivers=''"
+PACKAGECONFIG[gallium-llvm] = "-Dllvm=true -Dshared-llvm=true, -Dllvm=false, llvm${MESA_LLVM_RELEASE} llvm-native \
+                               ${@'elfutils' if ${GALLIUMDRIVERS_LLVM33_ENABLED} else ''}"
+PACKAGECONFIG[xa]  = "-Dgallium-xa=true, -Dgallium-xa=false"
+
+PACKAGECONFIG[lima] = ""
+GALLIUMDRIVERS_append ="${@bb.utils.contains('PACKAGECONFIG', 'lima', ',lima', '', d)}"
+
+PACKAGECONFIG[panfrost] = ""
+GALLIUMDRIVERS_append ="${@bb.utils.contains('PACKAGECONFIG', 'panfrost', ',panfrost', '', d)}"
+
+OSMESA = "${@bb.utils.contains('PACKAGECONFIG', 'gallium', 'gallium', 'classic', d)}"
+PACKAGECONFIG[osmesa] = "-Dosmesa=${OSMESA},-Dosmesa=none"
+
+PACKAGECONFIG[unwind] = "-Dlibunwind=true,-Dlibunwind=false,libunwind"
+
+# mesa tries to run cross-built gen_matypes on build machine to get struct size information
+EXTRA_OEMESON_append = " -Dasm=false"
+
+# llvmpipe is slow if compiled with -fomit-frame-pointer (e.g. -O2)
+FULL_OPTIMIZATION_append = " -fno-omit-frame-pointer"
+
+CFLAGS_append_armv5 = " -DMISSING_64BIT_ATOMICS"
+
+# Remove the mesa dependency on mesa-dev, as mesa is empty
+RDEPENDS_${PN}-dev = ""
+
+# Add dependency so that GLES3 header don't need to be added manually
+RDEPENDS_libgles2-mesa-dev += "libgles3-mesa-dev"
+
+PACKAGES =+ "libegl-mesa libegl-mesa-dev \
+             libosmesa libosmesa-dev \
+             libgl-mesa libgl-mesa-dev \
+             libglapi libglapi-dev \
+             libgbm libgbm-dev \
+             libgles1-mesa libgles1-mesa-dev \
+             libgles2-mesa libgles2-mesa-dev \
+             libgles3-mesa libgles3-mesa-dev \
+             libxatracker libxatracker-dev \
+             mesa-megadriver mesa-vulkan-drivers \
+            "
+
+do_install_append () {
+    # Drivers never need libtool .la files
+    rm -f ${D}${libdir}/dri/*.la
+    rm -f ${D}${libdir}/egl/*.la
+    rm -f ${D}${libdir}/gallium-pipe/*.la
+    rm -f ${D}${libdir}/gbm/*.la
+
+    # it was packaged in libdricore9.1.3-1 and preventing upgrades when debian.bbclass was used 
+    chrpath --delete ${D}${libdir}/dri/*_dri.so || true
+
+    # libwayland-egl has been moved to wayland 1.15+
+    rm -f ${D}${libdir}/libwayland-egl*
+    rm -f ${D}${libdir}/pkgconfig/wayland-egl.pc
+}
+
+# For the packages that make up the OpenGL interfaces, inject variables so that
+# they don't get Debian-renamed (which would remove the -mesa suffix), and
+# RPROVIDEs/RCONFLICTs on the generic libgl name.
+python __anonymous() {
+    pkgconfig = (d.getVar('PACKAGECONFIG') or "").split()
+    for p in (("egl", "libegl", "libegl1"),
+              ("dri", "libgl", "libgl1"),
+              ("gles", "libgles1", "libglesv1-cm1"),
+              ("gles", "libgles2", "libglesv2-2"),
+              ("gles", "libgles3",)):
+        if not p[0] in pkgconfig:
+            continue
+        fullp = p[1] + "-mesa"
+        pkgs = " ".join(p[1:])
+        d.setVar("DEBIAN_NOAUTONAME_" + fullp, "1")
+        d.appendVar("RREPLACES_" + fullp, pkgs)
+        d.appendVar("RPROVIDES_" + fullp, pkgs)
+        d.appendVar("RCONFLICTS_" + fullp, pkgs)
+
+        d.appendVar("RRECOMMENDS_" + fullp, " mesa-megadriver")
+
+        # For -dev, the first element is both the Debian and original name
+        fullp += "-dev"
+        pkgs = p[1] + "-dev"
+        d.setVar("DEBIAN_NOAUTONAME_" + fullp, "1")
+        d.appendVar("RREPLACES_" + fullp, pkgs)
+        d.appendVar("RPROVIDES_" + fullp, pkgs)
+        d.appendVar("RCONFLICTS_" + fullp, pkgs)
+}
+
+python mesa_populate_packages() {
+    pkgs = ['mesa', 'mesa-dev', 'mesa-dbg']
+    for pkg in pkgs:
+        d.setVar("RPROVIDES_%s" % pkg, pkg.replace("mesa", "mesa-dri", 1))
+        d.setVar("RCONFLICTS_%s" % pkg, pkg.replace("mesa", "mesa-dri", 1))
+        d.setVar("RREPLACES_%s" % pkg, pkg.replace("mesa", "mesa-dri", 1))
+
+    import re
+    dri_drivers_root = oe.path.join(d.getVar('PKGD'), d.getVar('libdir'), "dri")
+    if os.path.isdir(dri_drivers_root):
+        dri_pkgs = os.listdir(dri_drivers_root)
+        lib_name = d.expand("${MLPREFIX}mesa-megadriver")
+        for p in dri_pkgs:
+            m = re.match(r'^(.*)_dri\.so$', p)
+            if m:
+                pkg_name = " ${MLPREFIX}mesa-driver-%s" % legitimize_package_name(m.group(1))
+                d.appendVar("RPROVIDES_%s" % lib_name, pkg_name)
+                d.appendVar("RCONFLICTS_%s" % lib_name, pkg_name)
+                d.appendVar("RREPLACES_%s" % lib_name, pkg_name)
+
+    pipe_drivers_root = os.path.join(d.getVar('libdir'), "gallium-pipe")
+    do_split_packages(d, pipe_drivers_root, r'^pipe_(.*)\.so$', 'mesa-driver-pipe-%s', 'Mesa %s pipe driver', extra_depends='')
+}
+
+PACKAGESPLITFUNCS_prepend = "mesa_populate_packages "
+
+PACKAGES_DYNAMIC += "^mesa-driver-.*"
+
+FILES_mesa-megadriver = "${libdir}/dri/* ${datadir}/drirc.d/00-mesa-defaults.conf"
+FILES_mesa-vulkan-drivers = "${libdir}/libvulkan_*.so ${datadir}/vulkan"
+FILES_libegl-mesa = "${libdir}/libEGL.so.*"
+FILES_libgbm = "${libdir}/libgbm.so.*"
+FILES_libgles1-mesa = "${libdir}/libGLESv1*.so.*"
+FILES_libgles2-mesa = "${libdir}/libGLESv2.so.*"
+FILES_libgl-mesa = "${libdir}/libGL.so.*"
+FILES_libglapi = "${libdir}/libglapi.so.*"
+FILES_libosmesa = "${libdir}/libOSMesa.so.*"
+FILES_libxatracker = "${libdir}/libxatracker.so.*"
+
+FILES_${PN}-dev = "${libdir}/pkgconfig/dri.pc ${includedir}/vulkan"
+FILES_libegl-mesa-dev = "${libdir}/libEGL.* ${includedir}/EGL ${includedir}/KHR ${libdir}/pkgconfig/egl.pc"
+FILES_libgbm-dev = "${libdir}/libgbm.* ${libdir}/pkgconfig/gbm.pc ${includedir}/gbm.h"
+FILES_libgl-mesa-dev = "${libdir}/libGL.* ${includedir}/GL ${libdir}/pkgconfig/gl.pc"
+FILES_libglapi-dev = "${libdir}/libglapi.*"
+FILES_libgles1-mesa-dev = "${libdir}/libGLESv1*.* ${includedir}/GLES ${libdir}/pkgconfig/glesv1*.pc"
+FILES_libgles2-mesa-dev = "${libdir}/libGLESv2.* ${includedir}/GLES2 ${libdir}/pkgconfig/glesv2.pc"
+FILES_libgles3-mesa-dev = "${includedir}/GLES3"
+FILES_libosmesa-dev = "${libdir}/libOSMesa.* ${includedir}/GL/osmesa.h ${libdir}/pkgconfig/osmesa.pc"
+FILES_libxatracker-dev = "${libdir}/libxatracker.so ${libdir}/libxatracker.la \
+                          ${includedir}/xa_tracker.h ${includedir}/xa_composite.h ${includedir}/xa_context.h \
+                          ${libdir}/pkgconfig/xatracker.pc"
+
+# Fix upgrade path from mesa to mesa-megadriver
+RREPLACES_mesa-megadriver = "mesa"
+RCONFLICTS_mesa-megadriver = "mesa"
+RPROVIDES_mesa-megadriver = "mesa"

--- a/recipes-graphics/mesa/mesa_19.3.4.bb
+++ b/recipes-graphics/mesa/mesa_19.3.4.bb
@@ -1,0 +1,25 @@
+require ${BPN}.inc
+
+SRC_URI = "https://mesa.freedesktop.org/archive/mesa-${PV}.tar.xz \
+           file://0001-meson.build-check-for-all-linux-host_os-combinations.patch \
+           file://0002-meson.build-make-TLS-ELF-optional.patch \
+           file://0003-Allow-enable-DRI-without-DRI-drivers.patch \
+           file://0004-Revert-mesa-Enable-asm-unconditionally-now-that-gen_.patch \
+           file://0005-vc4-use-intmax_t-for-formatted-output-of-timespec-me.patch \
+           file://0001-meson-misdetects-64bit-atomics-on-mips-clang.patch \
+           "
+
+SRC_URI[md5sum] = "09e7700d9af511384d131fb77b5802cb"
+SRC_URI[sha256sum] = "1da467e6ae2799a517e242462331eafd29ae77d9872f3a845df81f7c308e8fe4"
+
+UPSTREAM_CHECK_GITTAGREGEX = "mesa-(?P<pver>\d+(\.\d+)+)"
+
+CFLAGS += "-fcommon"
+
+#because we cannot rely on the fact that all apps will use pkgconfig,
+#make eglplatform.h independent of MESA_EGL_NO_X11_HEADER
+do_install_append() {
+    if ${@bb.utils.contains('PACKAGECONFIG', 'egl', 'true', 'false', d)}; then
+        sed -i -e 's/^#elif defined(__unix__) && defined(EGL_NO_X11)$/#elif defined(__unix__) \&\& defined(EGL_NO_X11) || ${@bb.utils.contains('PACKAGECONFIG', 'x11', '0', '1', d)}/' ${D}${includedir}/EGL/eglplatform.h
+    fi
+}

--- a/recipes-graphics/mesa/mesa_20.0.0.bb
+++ b/recipes-graphics/mesa/mesa_20.0.0.bb
@@ -1,0 +1,27 @@
+require ${BPN}.inc
+
+SRC_URI = "https://mesa.freedesktop.org/archive/mesa-${PV}.tar.xz \
+           file://0001-meson.build-check-for-all-linux-host_os-combinations.patch \
+           file://0002-meson.build-make-TLS-ELF-optional.patch \
+           file://0003-Allow-enable-DRI-without-DRI-drivers.patch \
+           file://0004-Revert-mesa-Enable-asm-unconditionally-now-that-gen_.patch \
+           file://0005-vc4-use-intmax_t-for-formatted-output-of-timespec-me.patch \
+           file://0001-meson-misdetects-64bit-atomics-on-mips-clang.patch \
+           "
+
+SRC_URI[md5sum] = "681229d992bbd6250a5be4f308708795"
+SRC_URI[sha256sum] = "bb6db3e54b608d2536d4000b3de7dd3ae115fc114e8acbb5afff4b3bbed04b34"
+LIC_FILES_CHKSUM = "file://docs/license.html;md5=c1843d93c460bbf778d6037ce324f9f7"
+
+
+UPSTREAM_CHECK_GITTAGREGEX = "mesa-(?P<pver>\d+(\.\d+)+)"
+
+CFLAGS += "-fcommon"
+
+#because we cannot rely on the fact that all apps will use pkgconfig,
+#make eglplatform.h independent of MESA_EGL_NO_X11_HEADER
+do_install_append() {
+    if ${@bb.utils.contains('PACKAGECONFIG', 'egl', 'true', 'false', d)}; then
+        sed -i -e 's/^#elif defined(__unix__) && defined(EGL_NO_X11)$/#elif defined(__unix__) \&\& defined(EGL_NO_X11) || ${@bb.utils.contains('PACKAGECONFIG', 'x11', '0', '1', d)}/' ${D}${includedir}/EGL/eglplatform.h
+    fi
+}


### PR DESCRIPTION
`mesa-19.0.8` that is included with `poky` on `warrior` branch is too old for lima driver support (it doesn't include userspace driver for lima yet).

I copied recipe for mesa-19.3.4 from `poky` master with slight adaptation to warrior branch and then upgraded to freshly released 20.0.0 (see commits). The backport can be removed as soon as we upgrade to newer yocto release with newer mesa.

This is a pre-requisite for #2.