### PR TITLE
Compile XCSoar with KMS/OpenGL graphics

### DIFF
--- a/recipes-apps/xcsoar/files/0001-Disable-fast-math-optimization.patch
+++ b/recipes-apps/xcsoar/files/0001-Disable-fast-math-optimization.patch
@@ -1,0 +1,34 @@
+From 56e9ec0d943923502ac76fcb86673d73c65a1cbe Mon Sep 17 00:00:00 2001
+From: Andrey Lebedev <andrey@lebedev.lt>
+Date: Fri, 21 Feb 2020 21:31:05 +0000
+Subject: [PATCH] Disable fast-math optimization
+
+XCSoar compiled with OpenGL support and running under lima drivers
+renders a black screen if fast-math optimizations are enabled.
+---
+ build/debug.mk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/build/debug.mk b/build/debug.mk
+index f9159f1b1c..d50a7e59de 100644
+--- a/build/debug.mk
++++ b/build/debug.mk
+@@ -24,13 +24,13 @@ endif
+ # IEEE/ISO semantics, for example it is not interested in "errno" or
+ # the difference between -0 and +0.  This allows using non-conforming
+ # vector units on some platforms, e.g. ARM NEON.
+-OPTIMIZE += -ffast-math
++# OPTIMIZE += -ffast-math
+ 
+ ifeq ($(CLANG)$(DEBUG),nn)
+ # Enable gcc auto-vectorisation on some architectures (e.g. ARM NEON).
+ # This requires -ffast-math, because some vector units don't conform
+ # stricly with IEEE/ISO (see above).
+-OPTIMIZE += -ftree-vectorize
++# OPTIMIZE += -ftree-vectorize
+ 
+ OPTIMIZE += -funsafe-loop-optimizations
+ endif
+-- 
+2.20.1
+

--- a/recipes-apps/xcsoar/xcsoar-testing_git.bb
+++ b/recipes-apps/xcsoar/xcsoar-testing_git.bb
@@ -48,6 +48,7 @@ SRC_URI = " \
 	file://0001-Disable-warnings-as-errors.patch \
 	file://0001_no_version_lua.patch \
 	file://0001-avoid-tail-cut.patch \
+	file://0001-Disable-fast-math-optimization.patch \
 	file://ov-xcsoar.conf \
 "
 

--- a/recipes-apps/xcsoar/xcsoar-testing_git.bb
+++ b/recipes-apps/xcsoar/xcsoar-testing_git.bb
@@ -17,13 +17,18 @@ DEPENDS = "	\
 		librsvg-native \
 		imagemagick-native \
 		libinput \
-		libsdl \
 		lua \
 		udev \
 		ttf-dejavu \
 		jpeg \
 		freetype \
 		libpng \
+		glm \
+		virtual/egl \
+		virtual/mesa \
+		virtual/libgles1 \
+		virtual/libgles2 \
+		alsa-lib \
 "
 
 RDEPENDS_${PN} = "\
@@ -63,7 +68,7 @@ do_compile() {
 	echo "Making .."
 	echo '${WORKDIR}'
 	cd ${WORKDIR}/git
-	make -j$(nproc) DEBUG=n DEBUG_GLIBCXX=n USE_LIBINPUT=y GEOTIFF=n USE_FB=y OPENGL=n EGL=n
+	make -j$(nproc) DEBUG=n DEBUG_GLIBCXX=n ENABLE_MESA_KMS=y GEOTIFF=n
 }
 
 do_install() {


### PR DESCRIPTION
This will make XCSoar use of mesa and lima drivers. #6 and #7 are required for this to work.

This is a prerequisite for #2.