### PR TITLE
Include firmware for selected WIFI modules

### DIFF
--- a/recipes-core/images/openvario-base-image.bb
+++ b/recipes-core/images/openvario-base-image.bb
@@ -1,9 +1,28 @@
 SUMMARY = "A small image just capable of allowing a device to boot."
 
 IMAGE_FEATURES += "splash ssh-server-dropbear package-management"
+DEPENDS += "linux-firmware \
+    "
 
-IMAGE_INSTALL =     "packagegroup-base \
-                    "
+# Include common WIFI firmware packages into the image. All linux-firmware
+# packages take almost 500MB of space uncompressed, so we don't want to ship
+# all of them with the image. Ship image with most used firmware instead and
+# allow to download others with package manager
+COMMON_WIFI_FIRMWARE_PACKAGES = " \
+    linux-firmware-ralink \
+    linux-firmware-rtl8168 \
+    linux-firmware-rtl8188 \
+    linux-firmware-rtl8192ce \
+    linux-firmware-rtl8192cu \
+    linux-firmware-rtl8192su \
+    linux-firmware-rtl8723 \
+    linux-firmware-rtl8821 \
+"
+
+IMAGE_INSTALL = " \
+    packagegroup-base \
+    ${COMMON_WIFI_FIRMWARE_PACKAGES} \
+"
 
 #                    packagegroup-base packagegroup-core-ssh-openssh 
 


### PR DESCRIPTION
Including linux firmware with the image will allow to use various wifi dongles to set up connectivity in the field. 

The full firmware set is very large - around 500MB uncompressed and contains lots of irrelevant data, including firmware for various video cards. Shipping all of it with the image seems to be too wasteful. OTOH, not including the firmware at all will not allow users to set up wifi dongle to download it.

I propose including only selected firmware packages to support most popular wifi dongles.