### PR TITLE
Recipe for Syncthing

### DIFF
--- a/recipes-apps/syncthing/files/0001-Remove-root-user-warning.patch
+++ b/recipes-apps/syncthing/files/0001-Remove-root-user-warning.patch
@@ -1,0 +1,18 @@
+diff --git a/lib/syncthing/syncthing.go b/lib/syncthing/syncthing.go
+index 99fc23132..77f2bced6 100644
+--- a/lib/syncthing/syncthing.go
++++ b/lib/syncthing/syncthing.go
+@@ -336,10 +336,6 @@ func (a *App) startup() error {
+ 		}
+ 	}
+ 
+-	if isSuperUser() {
+-		l.Warnln("Syncthing should not run as a privileged or system user. Please consider using a normal user account.")
+-	}
+-
+ 	a.evLogger.Log(events.StartupComplete, map[string]string{
+ 		"myID": a.myID.String(),
+ 	})
+-- 
+2.20.1
+

--- a/recipes-apps/syncthing/files/syncthing.service
+++ b/recipes-apps/syncthing/files/syncthing.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Syncthing - Open Source Continuous File Synchronization
+Documentation=man:syncthing(1)
+
+[Service]
+Environment="HOME=/home/root"
+Environment="STNOUPGRADE=1"
+ExecStart=/usr/bin/syncthing -no-browser -no-restart -logflags=0 -gui-address="0.0.0.0:8384"
+Restart=on-failure
+SuccessExitStatus=3 4
+RestartForceExitStatus=3 4
+
+# Hardening
+SystemCallArchitectures=native
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=default.target

--- a/recipes-apps/syncthing/syncthing_1.3.4.bb
+++ b/recipes-apps/syncthing/syncthing_1.3.4.bb
@@ -16,6 +16,9 @@ FILES_${PN}-dev = ""
 
 SYSTEMD_SERVICE_${PN} = "syncthing.service"
 
+SYNCTHING_LDFLAGS = "-ldflags=' \
+    -X github.com/syncthing/syncthing/lib/build.Version=v${PV} \
+'"
 
 # Go creates read-only files for downloaded modules. To be able to clean them,
 # make them writable explicitly
@@ -29,8 +32,8 @@ python do_clean_prepend () {
 do_compile() {
     cd src/${GO_IMPORT}
     GO111MODULE=on ${GO} generate ${GOBUILDFLAGS} ${GO_IMPORT}/lib/auto ${GO_IMPORT}/cmd/strelaypoolsrv/auto
-    GO111MODULE=on ${GO} build ${GOBUILDFLAGS} ${GO_IMPORT}/cmd/syncthing
-    GO111MODULE=on ${GO} build ${GOBUILDFLAGS} ${GO_IMPORT}/cmd/stcli
+    GO111MODULE=on ${GO} build ${GOBUILDFLAGS} ${SYNCTHING_LDFLAGS} ${GO_IMPORT}/cmd/syncthing
+    GO111MODULE=on ${GO} build ${GOBUILDFLAGS} ${SYNCTHING_LDFLAGS} ${GO_IMPORT}/cmd/stcli
     chmod u+w -R ${WORKDIR}
 }
 

--- a/recipes-apps/syncthing/syncthing_1.3.4.bb
+++ b/recipes-apps/syncthing/syncthing_1.3.4.bb
@@ -1,0 +1,47 @@
+DESCRIPTION = "Syncthing - Open Source Continuous File Synchronization"
+HOMEPAGE = "https://syncthing.net/"
+
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=f75d2927d3c1ed2414ef72048f5ad640"
+GO_IMPORT = "github.com/syncthing/syncthing"
+SRC_URI = "git://${GO_IMPORT};protocol=git;tag=v${PV} \
+    file://0001-Remove-root-user-warning.patch;patchdir=src/${GO_IMPORT} \
+    file://syncthing.service \
+    "
+
+inherit go systemd
+
+
+FILES_${PN}-dev = ""
+
+SYSTEMD_SERVICE_${PN} = "syncthing.service"
+
+
+# Go creates read-only files for downloaded modules. To be able to clean them,
+# make them writable explicitly
+python do_clean_prepend () {
+    import subprocess
+
+    wdir = d.expand("${WORKDIR}")
+    subprocess.check_call(["chmod", "u+w", "-R", wdir])
+}
+
+do_compile() {
+    cd src/${GO_IMPORT}
+    GO111MODULE=on ${GO} generate ${GOBUILDFLAGS} ${GO_IMPORT}/lib/auto ${GO_IMPORT}/cmd/strelaypoolsrv/auto
+    GO111MODULE=on ${GO} build ${GOBUILDFLAGS} ${GO_IMPORT}/cmd/syncthing
+    GO111MODULE=on ${GO} build ${GOBUILDFLAGS} ${GO_IMPORT}/cmd/stcli
+    chmod u+w -R ${WORKDIR}
+}
+
+do_install() {
+        install -d ${D}${bindir}
+        install -m 0755 ${B}/src/${GO_IMPORT}/syncthing ${D}${bindir}/
+        install -m 0755 ${B}/src/${GO_IMPORT}/stcli ${D}${bindir}/
+        install -d ${D}${systemd_unitdir}/system
+        install -m 0755 ${B}/../syncthing.service ${D}${systemd_unitdir}/system
+}
+
+do_compile_ptest_base() {
+    :
+}

--- a/recipes-core/images/openvario-base-image.bb
+++ b/recipes-core/images/openvario-base-image.bb
@@ -2,6 +2,7 @@ SUMMARY = "A small image just capable of allowing a device to boot."
 
 IMAGE_FEATURES += "splash ssh-server-dropbear package-management"
 DEPENDS += "linux-firmware \
+    syncthing \
     "
 
 # Include common WIFI firmware packages into the image. All linux-firmware


### PR DESCRIPTION
This adds a recipe for [syncthing](https://syncthing.net/) - file synchronization program. This does not include syncthing into the image, but adds a package to opkg repository so users can install it and play with it. 

It is just a stock installation, without any Openvario-specific features. We can experiment with it and figure out the best way to use it.

After installation, syncthing will start its UI on port 8384, it should be accessible under url `http://<openvarioip>:8384`

Fixes #31.