### PR TITLE
Enable backlight brightness control

### DIFF
--- a/recipes-kernel/linux/linux-mainline/openvario-common.dts
+++ b/recipes-kernel/linux/linux-mainline/openvario-common.dts
@@ -227,22 +227,22 @@ cubiets@5c {
 		function = "lvds0";
 	};
 
-usb0_id_detect_pin: usb0_id_detect_pin@0 {
-	pins = "PH4";
-	function = "gpio_in";
-	bias-pull-up;
-};
+	usb0_id_detect_pin: usb0_id_detect_pin@0 {
+		pins = "PH4";
+		function = "gpio_in";
+		bias-pull-up;
+	};
 
-cubiets_int_pin:cubiets_int_pin@0 {
-	pins = "PH7";
-	function = "irq";
-	bias-pull-up;
-};
+	cubiets_int_pin:cubiets_int_pin@0 {
+		pins = "PH7";
+		function = "irq";
+		bias-pull-up;
+	};
 
-mmc2_cd_pin: mmc2_cd_pin@0 {
-	pins = "PH0";
-	function = "gpio_in";
-	bias-pull-up;
+	mmc2_cd_pin: mmc2_cd_pin@0 {
+		pins = "PH0";
+		function = "gpio_in";
+		bias-pull-up;
 	};
 };
 

--- a/recipes-kernel/linux/linux-mainline/openvario-common.dts
+++ b/recipes-kernel/linux/linux-mainline/openvario-common.dts
@@ -102,6 +102,7 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&lcd_lvds0_pins>;
 		enable-gpios = <&pio 7 9 GPIO_ACTIVE_HIGH>; /* PH9 */
+		backlight = <&backlight>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 
@@ -110,6 +111,14 @@
 				remote-endpoint = <&display_out_rgb>;
 			};
 		};
+	};
+
+	backlight: lcd {
+		compatible = "pwm-backlight";
+		pinctrl-names = "default";
+		pwms = <&pwm 0 5000000 0>;
+		brightness-levels = <0 8 16 32 64 128 255 384 512 768 1024>;
+		default-brightness-level = <10>;
 	};
 
 	leds {
@@ -244,6 +253,12 @@ cubiets@5c {
 		function = "gpio_in";
 		bias-pull-up;
 	};
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm0_pin>;
+	status = "okay";
 };
 
 &reg_ahci_5v {

--- a/recipes-kernel/linux/linux-mainline_5.2-rc2.bbappend
+++ b/recipes-kernel/linux/linux-mainline_5.2-rc2.bbappend
@@ -5,6 +5,8 @@ SRC_URI += " \
     file://openvario-common.dts \
     file://${KERNEL_DEVICETREE_SOURCE}"
 
+PR = "r1"
+
 # Create /etc/modprobe.d/lima.conf file
 # Make sure lima loads after drm modules, so that /dev/dri/card0 would be
 # claimed by sun4-drm modules (display driver) and card1 would belong to


### PR DESCRIPTION
Allow to change LCD backlight brightness with standard linux tools. Backlight can be controlled by writing to `/sys/class/backlight/lcd/brightness` file. Accepted values are in the range between 0 (backlight off) and 10 (full brightness). For example:

```
echo 8 > /sys/class/backlight/lcd/brightness
```

This also makes screen backlight to turn off when device is switched off in openvario menu.