### PR TITLE
Enable pulseaudio-based variod on testing image

### DIFF
--- a/recipes-apps/variod/files/variod.service
+++ b/recipes-apps/variod/files/variod.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Variod Daemon for Openvario
 Before=sensord.target
+Requires=pulseaudio.service
+After=pulseaudio.service
 
 [Service]
 Type=forking

--- a/recipes-apps/variod/variod-testing_git.bb
+++ b/recipes-apps/variod/variod-testing_git.bb
@@ -8,10 +8,10 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/${LICENSE};md5=c79ff39f19dfec6d
 SECTION = "base/app"
 
 DEPENDS = "\
-	alsa-lib \
+	pulseaudio \
 "
 
-PR = "r10"
+PR = "r11"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-core/images/openvario-base-image.bb
+++ b/recipes-core/images/openvario-base-image.bb
@@ -38,7 +38,12 @@ IMAGE_LINGUAS = " "
 
 LICENSE = "MIT"
 
-inherit core-image
+inherit core-image extrausers
 
 #IMAGE_ROOTFS_SIZE ?= "8192"
 IMAGE_ROOTFS_EXTRA_SPACE_append = "${@bb.utils.contains("DISTRO_FEATURES", "systemd", " + 4096", "" ,d)}"
+
+# Add root to audio group to allow root to use pulseaudio server
+EXTRA_USERS_PARAMS = "\
+    usermod -a -G audio root; \
+"

--- a/recipes-core/images/openvario-image-testing.bb
+++ b/recipes-core/images/openvario-image-testing.bb
@@ -14,6 +14,7 @@ IMAGE_INSTALL += "\
     variod-testing \
     ovmenu-ng \
     openvario-autologin \
+    pulseaudio-server \
 "
 
 export IMAGE_BASENAME = "openvario-image-testing"

--- a/recipes-multimedia/pulseaudio/files/pulseaudio.service
+++ b/recipes-multimedia/pulseaudio/files/pulseaudio.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Pulseaudio sound server
+
+[Service]
+Type=forking
+ExecStart=pulseaudio --daemonize=yes --system --realtime
+Restart=on-failure
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=default.target

--- a/recipes-multimedia/pulseaudio/pulseaudio_12.2.bbappend
+++ b/recipes-multimedia/pulseaudio/pulseaudio_12.2.bbappend
@@ -1,0 +1,13 @@
+# inherit extrausers
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://pulseaudio.service"
+
+SYSTEMD_PACKAGES = "${PN}-server"
+SYSTEMD_SERVICE_${PN}-server = "pulseaudio.service"
+FILES_${PN}-server += " ${systemd_unitdir}/system/pulseaudio.service "
+
+do_install_append() {
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${B}/../pulseaudio.service ${D}${systemd_unitdir}/system
+}


### PR DESCRIPTION
This adds pulseaudio on testing image and uses pulseaudio-enabled variod. Switching to pulseaudio-server based sound will also allow to mix XCSoar own sounds with vario.

Requires https://github.com/Openvario/variod/pull/1.

This is supposed to fix #18.