### PR TITLE
support all leagal file names and keep track of changes

### DIFF
--- a/recipes-apps/ovmenu-ng-skripts/files/download-xcsoar.sh
+++ b/recipes-apps/ovmenu-ng-skripts/files/download-xcsoar.sh
@@ -2,7 +2,7 @@
 
 USB_PATH="/usb/usbstick/openvario/download/xcsoar"
 DOWNLOAD_PATH="/home/root/.xcsoar"
-SAVE_FILE="${USB_PATH}/xcs-`date +'%Y-%m-%d'`.tgz"
+
 if [ ! -d "$USB_PATH" ]; then
 	mkdir "$USB_PATH"
 fi
@@ -10,11 +10,9 @@ fi
 if [ -z "$(ls $DOWNLOAD_PATH/* 2>/dev/null)" ]; then
         echo "No files found !!!"
 else
-	cd ${DOWNLOAD_PATH}
-	tar czf "${SAVE_FILE}" .
+        cp -rv "$SDOWNLOAD_PATH" "$USB_PATH"
 fi
 
-ls -l "${SAVE_FILE}"
 echo "Umount Stick ..."
 umount /dev/sda1
 echo "Done !!"

--- a/recipes-apps/ovmenu-ng-skripts/files/download-xcsoar.sh
+++ b/recipes-apps/ovmenu-ng-skripts/files/download-xcsoar.sh
@@ -2,18 +2,19 @@
 
 USB_PATH="/usb/usbstick/openvario/download/xcsoar"
 DOWNLOAD_PATH="/home/root/.xcsoar"
+SAVE_FILE="${USB_PATH}/xcs-`date +'%Y-%m-%d'`.tgz"
 if [ ! -d "$USB_PATH" ]; then
 	mkdir "$USB_PATH"
 fi
+
 if [ -z "$(ls $DOWNLOAD_PATH/* 2>/dev/null)" ]; then
         echo "No files found !!!"
 else
-        for downloadfile in $(find $DOWNLOAD_PATH -type f); do
-                echo $downloadfile
-                cp $downloadfile $USB_PATH
-        done
+	cd ${DOWNLOAD_PATH}
+	tar czf "${SAVE_FILE}" .
 fi
 
+ls -l "${SAVE_FILE}"
 echo "Umount Stick ..."
 umount /dev/sda1
 echo "Done !!"


### PR DESCRIPTION
A simple "cp $downloadfile $USB_PATH" fails with blanks in file names (and other nasty chars).
Use tar instead which can handle all legal file names and has 2 side effects:
1. keep multiple versions on the USB-stick
2. compress on the fly