### PR TITLE
Enable language switching for XCSoar

### DIFF
--- a/recipes-apps/ovmenu-ng/files/openvario-43-rgb/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-43-rgb/ovmenu-ng.sh
@@ -162,7 +162,7 @@ function submenu_xcsoar_lang() {
 		dialog --nocancel --backtitle "OpenVario" \
 		--title "[ S Y S T E M ]" \
 		--begin 3 4 \
-		--menu "Actual Setting is $XCSOAR_LANG \nSelect Language:" 15 50 4 \
+		--menu "Actual Setting is $XCSOAR_LANG \nSelect Language:" 15 50 12 \
 		 system "Default system" \
 		 de_DE.UTF-8 "German" \
 		 fr_FR.UTF-8 "France" \
@@ -170,7 +170,9 @@ function submenu_xcsoar_lang() {
 		 hu_HU.UTF-8 "Hungary" \
 		 pl_PL.UTF-8 "Poland" \
 		 cs_CZ.UTF-8 "Czech" \
-	 	 sk_SK.UTF-8 "Slowak" \
+		 sk_SK.UTF-8 "Slowak" \
+		 lt_LT.UTF-8 "Lithuanian" \
+		 ru_RU.UTF-8 "Russian" \
 		 2>"${INPUT}"
 		 
 		 menuitem=$(<"${INPUT}")

--- a/recipes-apps/ovmenu-ng/files/openvario-57-lvds/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-57-lvds/ovmenu-ng.sh
@@ -162,7 +162,7 @@ function submenu_xcsoar_lang() {
 		dialog --nocancel --backtitle "OpenVario" \
 		--title "[ S Y S T E M ]" \
 		--begin 3 4 \
-		--menu "Actual Setting is $XCSOAR_LANG \nSelect Language:" 15 50 4 \
+		--menu "Actual Setting is $XCSOAR_LANG \nSelect Language:" 15 50 12 \
 		 system "Default system" \
 		 de_DE.UTF-8 "German" \
 		 fr_FR.UTF-8 "France" \
@@ -170,7 +170,9 @@ function submenu_xcsoar_lang() {
 		 hu_HU.UTF-8 "Hungary" \
 		 pl_PL.UTF-8 "Poland" \
 		 cs_CZ.UTF-8 "Czech" \
-	 	 sk_SK.UTF-8 "Slowak" \
+		 sk_SK.UTF-8 "Slowak" \
+		 lt_LT.UTF-8 "Lithuanian" \
+		 ru_RU.UTF-8 "Russian" \
 		 2>"${INPUT}"
 		 
 		 menuitem=$(<"${INPUT}")

--- a/recipes-apps/ovmenu-ng/files/openvario-7-CH070/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-7-CH070/ovmenu-ng.sh
@@ -162,7 +162,7 @@ function submenu_xcsoar_lang() {
 		dialog --nocancel --backtitle "OpenVario" \
 		--title "[ S Y S T E M ]" \
 		--begin 3 4 \
-		--menu "Actual Setting is $XCSOAR_LANG \nSelect Language:" 15 50 4 \
+		--menu "Actual Setting is $XCSOAR_LANG \nSelect Language:" 15 50 12 \
 		 system "Default system" \
 		 de_DE.UTF-8 "German" \
 		 fr_FR.UTF-8 "France" \
@@ -170,7 +170,9 @@ function submenu_xcsoar_lang() {
 		 hu_HU.UTF-8 "Hungary" \
 		 pl_PL.UTF-8 "Poland" \
 		 cs_CZ.UTF-8 "Czech" \
-	 	 sk_SK.UTF-8 "Slowak" \
+		 sk_SK.UTF-8 "Slowak" \
+		 lt_LT.UTF-8 "Lithuanian" \
+		 ru_RU.UTF-8 "Russian" \
 		 2>"${INPUT}"
 		 
 		 menuitem=$(<"${INPUT}")

--- a/recipes-apps/ovmenu-ng/files/openvario-7-PQ070/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-7-PQ070/ovmenu-ng.sh
@@ -162,7 +162,7 @@ function submenu_xcsoar_lang() {
 		dialog --nocancel --backtitle "OpenVario" \
 		--title "[ S Y S T E M ]" \
 		--begin 3 4 \
-		--menu "Actual Setting is $XCSOAR_LANG \nSelect Language:" 15 50 4 \
+		--menu "Actual Setting is $XCSOAR_LANG \nSelect Language:" 15 50 12 \
 		 system "Default system" \
 		 de_DE.UTF-8 "German" \
 		 fr_FR.UTF-8 "France" \
@@ -170,7 +170,9 @@ function submenu_xcsoar_lang() {
 		 hu_HU.UTF-8 "Hungary" \
 		 pl_PL.UTF-8 "Poland" \
 		 cs_CZ.UTF-8 "Czech" \
-	 	 sk_SK.UTF-8 "Slowak" \
+		 sk_SK.UTF-8 "Slowak" \
+		 lt_LT.UTF-8 "Lithuanian" \
+		 ru_RU.UTF-8 "Russian" \
 		 2>"${INPUT}"
 		 
 		 menuitem=$(<"${INPUT}")

--- a/recipes-core/images/openvario-base-image.bb
+++ b/recipes-core/images/openvario-base-image.bb
@@ -19,6 +19,18 @@ COMMON_WIFI_FIRMWARE_PACKAGES = " \
     linux-firmware-rtl8821 \
 "
 
+LOCALE_PACKAGES = " \
+    locale-base-en-us \
+    locale-base-de-de \
+    locale-base-es-es \
+    locale-base-fr-fr \
+    locale-base-it-it \
+    locale-base-hu-hu \
+    locale-base-pl-pl \
+    locale-base-cs-cz \
+    locale-base-sk-sk \
+"
+
 IMAGE_INSTALL = " \
     packagegroup-base \
     distro-feed-configs \
@@ -28,6 +40,7 @@ IMAGE_INSTALL = " \
     nano \
     openssh-sftp-server \
     ${COMMON_WIFI_FIRMWARE_PACKAGES} \
+    ${LOCALE_PACKAGES} \
 "
 
 #                    packagegroup-base packagegroup-core-ssh-openssh 

--- a/recipes-core/images/openvario-base-image.bb
+++ b/recipes-core/images/openvario-base-image.bb
@@ -29,6 +29,8 @@ LOCALE_PACKAGES = " \
     locale-base-pl-pl \
     locale-base-cs-cz \
     locale-base-sk-sk \
+    locale-base-ru-ru \
+    locale-base-lt-lt \
 "
 
 IMAGE_INSTALL = " \


### PR DESCRIPTION
Include locales to enable language switching for XCSoar. As a bonus, add Lithuanian and Russian languages to the selection.

Fixes #48.