### PR TITLE
Include pulseaudio in stable image

### DIFF
--- a/recipes-apps/variod/variod_0.3.0.bb
+++ b/recipes-apps/variod/variod_0.3.0.bb
@@ -1,0 +1,60 @@
+# Copyright (C) 2014 Unknow User <unknow@user.org>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "Variod Daemon for Openvario"
+HOMEPAGE = "www.openvario.org"
+LICENSE = "GPL-3.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/${LICENSE};md5=c79ff39f19dfec6d293b95dea7b07891"
+SECTION = "base/app"
+PR = "r0"
+
+S = "${WORKDIR}/git"
+
+INSANE_SKIP_${PN} += "ldflags"
+
+inherit systemd
+
+DEPENDS = " \
+	pulseaudio \
+	libgcc \
+	"
+
+SRC_URI = "git://github.com/Openvario/variod.git;protocol=git;tag=${PV} \
+			  file://variod.service \
+			  file://variod.cfgmgr \
+"
+
+do_compile() {
+	echo "Making .."
+	echo '${WORKDIR}'
+	cd ${WORKDIR}/git
+	make clean
+	make
+}
+
+do_install() {
+	install -d ${D}/opt/bin
+	install -d ${D}/opt/conf/default
+	install -d ${D}/opt/conf
+	install -m 0755 ${S}/variod ${D}/opt/bin
+	install -m 0755 ${S}/variod.conf ${D}/opt/conf/default
+	install -m 0755 ${S}/variod.conf ${D}/opt/conf
+
+	install -d ${D}/etc/cfgmgr.d
+	install -m 0755 ${WORKDIR}/variod.cfgmgr ${D}/etc/cfgmgr.d/variod.cfgmgr
+
+	install -d ${D}${systemd_unitdir}/system
+	install -m 0644 ${WORKDIR}/variod.service ${D}${systemd_unitdir}/system
+}
+
+PACKAGES = "${PN}"
+INHIBIT_PACKAGE_DEBUG_SPLIT = '1'
+FILES_${PN} = "/opt/bin/variod \
+					/opt/conf/default/variod.conf \
+					/opt/conf/variod.conf \
+					/etc/cfgmgr.d/variod.cfgmgr \
+					${systemd_unitdir}/system/variod.service \
+"
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE_${PN} = "variod.service"

--- a/recipes-core/images/openvario-base-image.bb
+++ b/recipes-core/images/openvario-base-image.bb
@@ -41,6 +41,7 @@ IMAGE_INSTALL = " \
     autofs-config \
     nano \
     openssh-sftp-server \
+    pulseaudio-server \
     ${COMMON_WIFI_FIRMWARE_PACKAGES} \
     ${LOCALE_PACKAGES} \
 "

--- a/recipes-core/images/openvario-image-testing.bb
+++ b/recipes-core/images/openvario-image-testing.bb
@@ -14,7 +14,6 @@ IMAGE_INSTALL += "\
     variod-testing \
     ovmenu-ng \
     openvario-autologin \
-    pulseaudio-server \
 "
 
 export IMAGE_BASENAME = "openvario-image-testing"


### PR DESCRIPTION
Preliminary testing showed that pulsaudio-enabled variod works well,
so include it in stable image as well. There should be no risk,
considering that old variod doesn't work at all on newer images.