### PR TITLE
recipes-core/images/openvario-base-image.bb: add git

### DIFF
--- a/recipes-core/images/openvario-base-image.bb
+++ b/recipes-core/images/openvario-base-image.bb
@@ -2,7 +2,8 @@ SUMMARY = "A small image just capable of allowing a device to boot."
 
 IMAGE_FEATURES += "splash ssh-server-dropbear package-management"
 DEPENDS += "linux-firmware \
-    "
+    git \
+"
 
 # Include common WIFI firmware packages into the image. All linux-firmware
 # packages take almost 500MB of space uncompressed, so we don't want to ship


### PR DESCRIPTION
Apart from various cloud services, git can be used to manage the xcsoar data folder between different machines. This PR integrates git into the base image.