### PR TITLE
Include opkg feeds from usb stick

### DIFF
--- a/recipes-core/meta/distro-feed-configs.bbappend
+++ b/recipes-core/meta/distro-feed-configs.bbappend
@@ -1,0 +1,9 @@
+# Include opkg feed file to usb stick
+USB_FEED_URI = "file:///usb/usbstick/openvario/repo"
+
+do_compile_append() {
+    rm -f ${S}/${sysconfdir}/opkg/usb-feed.conf
+    for feed in ${DISTRO_FEED_ARCHS}; do
+        echo "src/gz usb-${feed} ${USB_FEED_URI}/${feed}" >> ${S}/${sysconfdir}/opkg/usb-feed.conf
+    done
+}


### PR DESCRIPTION
This will add `/etc/opkg/usb-feed.conf` file to configure opkg to look for repo in `usb/usbstick/openvario/repo`.

Fixes #66