### PR TITLE
Populate missing system info values

### DIFF
--- a/recipes-apps/ovmenu-ng/files/openvario-43-rgb/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-43-rgb/ovmenu-ng.sh
@@ -108,11 +108,10 @@ function submenu_system() {
 function show_info() {
 	### collect info of system
 	XCSOAR_VERSION=$(opkg list-installed xcsoar | awk -F' ' '{print $3}')
-	XCSOAR_MAPS_FLARMNET=$(opkg list-installed xcsoar-maps-flarmnet | awk -F' ' '{print $3}')
 	XCSOAR_MAPS_VERSION=$(opkg list-installed | grep "xcsoar-maps-" | awk -F' ' '{print $3}')
-	IMAGE_VERSION=$(more /etc/version | awk -F' ' '{print $2}')
-	SENSORD_VERSION=$(opkg list-installed sensord | awk -F' ' '{print $3}')
-	VARIOD_VERSION=$(opkg list-installed variod | awk -F' ' '{print $3}')
+	IMAGE_VERSION=$(cat /etc/os-release | grep VERSION_ID | awk -F'=' -F'"' '{print $2}')
+	SENSORD_VERSION=$(opkg list-installed sensord* | awk -F' ' '{print $3}')
+	VARIOD_VERSION=$(opkg list-installed variod* | awk -F' ' '{print $3}')
 	IP_ETH0=$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
 	IP_WLAN=$(/sbin/ifconfig wlan0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
 	
@@ -124,7 +123,6 @@ function show_info() {
 	Image: $IMAGE_VERSION\n \
 	XCSoar: $XCSOAR_VERSION\n \
 	Maps: $XCSOAR_MAPS_VERSION\n \
-	Flarmnet: $XCSOAR_MAPS_FLARMNET\n \
 	sensord: $SENSORD_VERSION\n \
 	variod: $VARIOD_VERSION\n \
 	IP eth0: $IP_ETH0\n \

--- a/recipes-apps/ovmenu-ng/files/openvario-57-lvds/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-57-lvds/ovmenu-ng.sh
@@ -108,11 +108,10 @@ function submenu_system() {
 function show_info() {
 	### collect info of system
 	XCSOAR_VERSION=$(opkg list-installed xcsoar | awk -F' ' '{print $3}')
-	XCSOAR_MAPS_FLARMNET=$(opkg list-installed xcsoar-maps-flarmnet | awk -F' ' '{print $3}')
 	XCSOAR_MAPS_VERSION=$(opkg list-installed | grep "xcsoar-maps-" | awk -F' ' '{print $3}')
-	IMAGE_VERSION=$(more /etc/version | awk -F' ' '{print $2}')
-	SENSORD_VERSION=$(opkg list-installed sensord | awk -F' ' '{print $3}')
-	VARIOD_VERSION=$(opkg list-installed variod | awk -F' ' '{print $3}')
+	IMAGE_VERSION=$(cat /etc/os-release | grep VERSION_ID | awk -F'=' -F'"' '{print $2}')
+	SENSORD_VERSION=$(opkg list-installed sensord* | awk -F' ' '{print $3}')
+	VARIOD_VERSION=$(opkg list-installed variod* | awk -F' ' '{print $3}')
 	IP_ETH0=$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
 	IP_WLAN=$(/sbin/ifconfig wlan0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
 	
@@ -124,7 +123,6 @@ function show_info() {
 	Image: $IMAGE_VERSION\n \
 	XCSoar: $XCSOAR_VERSION\n \
 	Maps: $XCSOAR_MAPS_VERSION\n \
-	Flarmnet: $XCSOAR_MAPS_FLARMNET\n \
 	sensord: $SENSORD_VERSION\n \
 	variod: $VARIOD_VERSION\n \
 	IP eth0: $IP_ETH0\n \

--- a/recipes-apps/ovmenu-ng/files/openvario-7-CH070/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-7-CH070/ovmenu-ng.sh
@@ -108,11 +108,10 @@ function submenu_system() {
 function show_info() {
 	### collect info of system
 	XCSOAR_VERSION=$(opkg list-installed xcsoar | awk -F' ' '{print $3}')
-	XCSOAR_MAPS_FLARMNET=$(opkg list-installed xcsoar-maps-flarmnet | awk -F' ' '{print $3}')
 	XCSOAR_MAPS_VERSION=$(opkg list-installed | grep "xcsoar-maps-" | awk -F' ' '{print $3}')
-	IMAGE_VERSION=$(more /etc/version | awk -F' ' '{print $2}')
-	SENSORD_VERSION=$(opkg list-installed sensord | awk -F' ' '{print $3}')
-	VARIOD_VERSION=$(opkg list-installed variod | awk -F' ' '{print $3}')
+	IMAGE_VERSION=$(cat /etc/os-release | grep VERSION_ID | awk -F'=' -F'"' '{print $2}')
+	SENSORD_VERSION=$(opkg list-installed sensord* | awk -F' ' '{print $3}')
+	VARIOD_VERSION=$(opkg list-installed variod* | awk -F' ' '{print $3}')
 	IP_ETH0=$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
 	IP_WLAN=$(/sbin/ifconfig wlan0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
 	
@@ -124,7 +123,6 @@ function show_info() {
 	Image: $IMAGE_VERSION\n \
 	XCSoar: $XCSOAR_VERSION\n \
 	Maps: $XCSOAR_MAPS_VERSION\n \
-	Flarmnet: $XCSOAR_MAPS_FLARMNET\n \
 	sensord: $SENSORD_VERSION\n \
 	variod: $VARIOD_VERSION\n \
 	IP eth0: $IP_ETH0\n \

--- a/recipes-apps/ovmenu-ng/files/openvario-7-PQ070/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-7-PQ070/ovmenu-ng.sh
@@ -108,11 +108,10 @@ function submenu_system() {
 function show_info() {
 	### collect info of system
 	XCSOAR_VERSION=$(opkg list-installed xcsoar | awk -F' ' '{print $3}')
-	XCSOAR_MAPS_FLARMNET=$(opkg list-installed xcsoar-maps-flarmnet | awk -F' ' '{print $3}')
 	XCSOAR_MAPS_VERSION=$(opkg list-installed | grep "xcsoar-maps-" | awk -F' ' '{print $3}')
-	IMAGE_VERSION=$(more /etc/version | awk -F' ' '{print $2}')
-	SENSORD_VERSION=$(opkg list-installed sensord | awk -F' ' '{print $3}')
-	VARIOD_VERSION=$(opkg list-installed variod | awk -F' ' '{print $3}')
+	IMAGE_VERSION=$(cat /etc/os-release | grep VERSION_ID | awk -F'=' -F'"' '{print $2}')
+	SENSORD_VERSION=$(opkg list-installed sensord* | awk -F' ' '{print $3}')
+	VARIOD_VERSION=$(opkg list-installed variod* | awk -F' ' '{print $3}')
 	IP_ETH0=$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
 	IP_WLAN=$(/sbin/ifconfig wlan0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
 	
@@ -124,7 +123,6 @@ function show_info() {
 	Image: $IMAGE_VERSION\n \
 	XCSoar: $XCSOAR_VERSION\n \
 	Maps: $XCSOAR_MAPS_VERSION\n \
-	Flarmnet: $XCSOAR_MAPS_FLARMNET\n \
 	sensord: $SENSORD_VERSION\n \
 	variod: $VARIOD_VERSION\n \
 	IP eth0: $IP_ETH0\n \


### PR DESCRIPTION
Fixes lookup of relevant versions. Also removes flarmnet
version because it is now downloadable directly from XCsoar
and we don't seem to include it.

Fixes #60