### PR TITLE
Make logs persistent between reboots

### DIFF
--- a/conf/distro/ovlinux.conf
+++ b/conf/distro/ovlinux.conf
@@ -40,6 +40,10 @@ DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${DISTRO_FEATURES_LIBC} ${POKY_DE
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 
+# Make /var/log dir persistent on the filesystem. By default logs are located
+# on in-memory /var/volatile/log dir. Helps with debugging freezes.
+VOLATILE_LOG_DIR = "no"
+
 TCLIBCAPPEND = ""
 
 IMAGE_INSTALL_append = " connman connman-client"


### PR DESCRIPTION
By default logs are located in ramdisk-mounted directory `/var/volatile/log`, so they do not survive reboots. In order to make debugging "freezing in flight" issues (such as #71) easier, store logs on a persistent filesystem.