### PR TITLE
Designate sensord.conf as a config file

### DIFF
--- a/recipes-apps/sensord/sensord-testing_git.bb
+++ b/recipes-apps/sensord/sensord-testing_git.bb
@@ -7,7 +7,7 @@ LICENSE = "GPL-3.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/${LICENSE};md5=c79ff39f19dfec6d293b95dea7b07891"
 SECTION = "base/app"
 DEPENDS = ""
-PR = "r8"
+PR = "r9"
 
 S = "${WORKDIR}/git"
 
@@ -52,9 +52,13 @@ INHIBIT_PACKAGE_DEBUG_SPLIT = '1'
 
 FILES_${PN} = "/opt/bin/sensord \
 					/opt/bin/sensorcal \
-					/opt/conf/sensord.conf \
 					/opt/conf/default/sensord.conf \
 					/etc/cfgmgr.d/sensord.cfgmgr \
+					/opt/conf/sensord.conf \
+"
+
+CONFFILES_${PN} = " \
+	/opt/conf/sensord.conf \
 "
 
 FILES_${PN}-dev = "/usr/src/debug/sensord-testing/git-r7/git/*"


### PR DESCRIPTION
This way opkg will not replace user-modified config file on package
upgrade and custom configuration will not be lost.