### PR TITLE
Make touchscreen work

### DIFF
--- a/recipes-apps/ovmenu-ng-skripts/files/ov-calibrate-ts.sh
+++ b/recipes-apps/ovmenu-ng-skripts/files/ov-calibrate-ts.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+ROT=`cat /sys/class/graphics/fbcon/rotate`
+
+# Perform the calibration
+TSLIB_TSDEVICE=/dev/input/touchscreen0 ts_calibrate -r $ROT
+
+echo "Applying the libinput calibration matrix according to current rotation ($ROT)"
+case $ROT in
+    0) ROTMATRIX="1 0 0 0 1 0" ;;
+    1) ROTMATRIX="0 1 0 -1 0 1" ;;
+    2) ROTMATRIX="-1 0 1 0 -1 1" ;;
+    3) ROTMATRIX="0 -1 1 1 0 0" ;;
+esac
+
+echo "ENV{LIBINPUT_CALIBRATION_MATRIX}=\"$ROTMATRIX\"" > /etc/udev/rules.d/libinput-ts.rules
+udevadm control --reload
+udevadm trigger
+
+echo Restart ts_uinput
+systemctl restart ts_uinput

--- a/recipes-apps/ovmenu-ng-skripts/ovmenu-ng-skripts_0.1.bb
+++ b/recipes-apps/ovmenu-ng-skripts/ovmenu-ng-skripts_0.1.bb
@@ -20,6 +20,7 @@ SRC_URI =      "\
 	file://upload-all.sh \
 	file://upload-xcsoar.sh \
 	file://download-all.sh \
+	file://ov-calibrate-ts.sh \
 "
 
 
@@ -39,6 +40,7 @@ do_install() {
 		install -m 0755 ${S}/upload-all.sh ${D}/usr/bin/upload-all.sh
 		install -m 0755 ${S}/upload-xcsoar.sh ${D}/usr/bin/upload-xcsoar.sh
 		install -m 0755 ${S}/download-all.sh ${D}/usr/bin/download-all.sh
+		install -m 0755 ${S}/ov-calibrate-ts.sh ${D}/usr/bin/ov-calibrate-ts.sh
 }
 
 FILES_${PN} = "/usr/bin/xcsoar_config.sh \
@@ -48,4 +50,5 @@ FILES_${PN} = "/usr/bin/xcsoar_config.sh \
 				/usr/bin/upload-all.sh \
 				/usr/bin/download-all.sh \
 				/usr/bin/upload-xcsoar.sh \
+				/usr/bin/ov-calibrate-ts.sh \
 "

--- a/recipes-apps/ovmenu-ng/files/openvario-43-rgb/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-43-rgb/ovmenu-ng.sh
@@ -302,10 +302,8 @@ function calibrate_sensors() {
 
 function calibrate_touch() {
 	echo "Calibrating Touch ..." >> /tmp/tail.$$
-	# reset touch calibration
-	# uboot rotation
-	ts_calibrate -r $(cat /sys/class/graphics/fbcon/rotate)
-	dialog --msgbox "Calibration OK !!\nPlease reboot to apply !!" 10 50
+	/usr/bin/ov-calibrate-ts.sh >> /tmp/tail.$$
+	dialog --msgbox "Calibration OK!" 10 50
 }
 
 # Copy /usb/usbstick/openvario/maps to /home/root/.xcsoar

--- a/recipes-apps/ovmenu-ng/files/openvario-57-lvds/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-57-lvds/ovmenu-ng.sh
@@ -302,10 +302,8 @@ function calibrate_sensors() {
 
 function calibrate_touch() {
 	echo "Calibrating Touch ..." >> /tmp/tail.$$
-	# reset touch calibration
-	# uboot rotation
-	ts_calibrate -r $(cat /sys/class/graphics/fbcon/rotate)
-	dialog --msgbox "Calibration OK !!\nPlease reboot to apply !!" 10 50
+	/usr/bin/ov-calibrate-ts.sh >> /tmp/tail.$$
+	dialog --msgbox "Calibration OK!" 10 50
 }
 
 # Copy /usb/usbstick/openvario/maps to /home/root/.xcsoar

--- a/recipes-apps/ovmenu-ng/files/openvario-7-CH070/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-7-CH070/ovmenu-ng.sh
@@ -302,10 +302,8 @@ function calibrate_sensors() {
 
 function calibrate_touch() {
 	echo "Calibrating Touch ..." >> /tmp/tail.$$
-	# reset touch calibration
-	# uboot rotation
-	ts_calibrate -r $(cat /sys/class/graphics/fbcon/rotate)
-	dialog --msgbox "Calibration OK !!\nPlease reboot to apply !!" 10 50
+	/usr/bin/ov-calibrate-ts.sh >> /tmp/tail.$$
+	dialog --msgbox "Calibration OK!" 10 50
 }
 
 # Copy /usb/usbstick/openvario/maps to /home/root/.xcsoar

--- a/recipes-apps/ovmenu-ng/files/openvario-7-PQ070/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-7-PQ070/ovmenu-ng.sh
@@ -302,10 +302,8 @@ function calibrate_sensors() {
 
 function calibrate_touch() {
 	echo "Calibrating Touch ..." >> /tmp/tail.$$
-	# reset touch calibration
-	# uboot rotation
-	ts_calibrate -r $(cat /sys/class/graphics/fbcon/rotate)
-	dialog --msgbox "Calibration OK !!\nPlease reboot to apply !!" 10 50
+	/usr/bin/ov-calibrate-ts.sh >> /tmp/tail.$$
+	dialog --msgbox "Calibration OK!" 10 50
 }
 
 # Copy /usb/usbstick/openvario/maps to /home/root/.xcsoar

--- a/recipes-graphics/tslib/tslib/0001-Fix-build-error-with-input_event_sec-for-old-kernel.patch
+++ b/recipes-graphics/tslib/tslib/0001-Fix-build-error-with-input_event_sec-for-old-kernel.patch
@@ -1,0 +1,30 @@
+From 050bf24c16e95f63a76e13156346a072035d45b4 Mon Sep 17 00:00:00 2001
+From: Evan Harvey <evanwork1234@gmail.com>
+Date: Thu, 19 Mar 2020 01:32:03 -0700
+Subject: [PATCH] Fix build error with input_event_sec for old kernel
+
+Upstream-Status: Backport [https://github.com/libts/tslib/commit/050bf24c16e95f63a76e13156346a072035d45b4]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ tools/ts_uinput.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/tools/ts_uinput.c b/tools/ts_uinput.c
+index 1832a07..9c40bb3 100644
+--- a/tools/ts_uinput.c
++++ b/tools/ts_uinput.c
+@@ -51,6 +51,11 @@
+ #include <linux/fb.h>
+ #endif
+ 
++#ifndef input_event_sec
++#define input_event_sec time.tv_sec
++#define input_event_usec time.tv_usec
++#endif
++
+ #define RESET   "\033[0m"
+ #define RED     "\033[31m"
+ #define GREEN   "\033[32m"
+-- 
+2.26.2
+

--- a/recipes-graphics/tslib/tslib/0001-Fix-build-on-32bit-arches-with-64bit-time_t.patch
+++ b/recipes-graphics/tslib/tslib/0001-Fix-build-on-32bit-arches-with-64bit-time_t.patch
@@ -1,0 +1,389 @@
+From 5455055660700be18eb8800e56e2423031ed4c76 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 30 Nov 2019 19:59:29 -0800
+Subject: [PATCH] Fix build on 32bit arches with 64bit time_t
+
+time element is deprecated on new input_event structure in kernel's
+input.h [1]
+
+[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=152194fe9c3f
+
+Upstream-Status: Submitted [https://github.com/libts/tslib/pull/162]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ plugins/input-raw.c | 59 +++++++++++++++++++++++++++-------------
+ tools/ts_uinput.c   | 66 ++++++++++++++++++++++++++++++---------------
+ 2 files changed, 85 insertions(+), 40 deletions(-)
+
+diff --git a/plugins/input-raw.c b/plugins/input-raw.c
+index 64f0156..f030836 100644
+--- a/plugins/input-raw.c
++++ b/plugins/input-raw.c
+@@ -40,6 +40,11 @@
+ # include <linux/input.h>
+ #endif
+ 
++#ifndef input_event_sec
++#define input_event_sec time.tv_sec
++#define input_event_usec time.tv_usec
++#endif
++
+ #ifndef EV_SYN /* 2.4 kernel headers */
+ # define EV_SYN 0x00
+ #endif
+@@ -384,7 +389,8 @@ static int ts_input_read(struct tslib_module_info *inf,
+ 						samp->y = i->current_y;
+ 						samp->pressure = i->current_p;
+ 					}
+-					samp->tv = ev.time;
++					samp->tv.tv_sec = ev.input_event_sec;
++					samp->tv.tv_usec = ev.input_event_usec;
+ 			#ifdef DEBUG
+ 				fprintf(stderr,
+ 					"RAW---------------------> %d %d %d %ld.%ld\n",
+@@ -519,7 +525,8 @@ static int ts_input_read(struct tslib_module_info *inf,
+ 					samp->pressure = i->current_p = ev.value;
+ 					break;
+ 				}
+-				samp->tv = ev.time;
++				samp->tv.tv_sec = ev.input_event_sec;
++				samp->tv.tv_usec = ev.input_event_usec;
+ 	#ifdef DEBUG
+ 				fprintf(stderr,
+ 					"RAW---------------------------> %d %d %d\n",
+@@ -536,7 +543,8 @@ static int ts_input_read(struct tslib_module_info *inf,
+ 						samp->x = 0;
+ 						samp->y = 0;
+ 						samp->pressure = 0;
+-						samp->tv = ev.time;
++						samp->tv.tv_sec = ev.input_event_sec;
++						samp->tv.tv_usec = ev.input_event_usec;
+ 						samp++;
+ 						total++;
+ 					}
+@@ -651,7 +659,8 @@ static int ts_input_read_mt(struct tslib_module_info *inf,
+ 				switch (i->ev[it].code) {
+ 				case BTN_TOUCH:
+ 					i->buf[total][i->slot].pen_down = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 					if (i->ev[it].value == 0)
+ 						pen_up = 1;
+@@ -751,7 +760,8 @@ static int ts_input_read_mt(struct tslib_module_info *inf,
+ 					// fall through
+ 				case ABS_MT_POSITION_X:
+ 					i->buf[total][i->slot].x = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 					break;
+ 				case ABS_Y:
+@@ -760,7 +770,8 @@ static int ts_input_read_mt(struct tslib_module_info *inf,
+ 					// fall through
+ 				case ABS_MT_POSITION_Y:
+ 					i->buf[total][i->slot].y = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 					break;
+ 				case ABS_PRESSURE:
+@@ -769,12 +780,14 @@ static int ts_input_read_mt(struct tslib_module_info *inf,
+ 					// fall through
+ 				case ABS_MT_PRESSURE:
+ 					i->buf[total][i->slot].pressure = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 					break;
+ 				case ABS_MT_TOOL_X:
+ 					i->buf[total][i->slot].tool_x = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 					/* for future use
+ 					 * i->buf[total][i->slot].valid |= TSLIB_MT_VALID_TOOL;
+@@ -782,7 +795,8 @@ static int ts_input_read_mt(struct tslib_module_info *inf,
+ 					break;
+ 				case ABS_MT_TOOL_Y:
+ 					i->buf[total][i->slot].tool_y = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 					/* for future use
+ 					 * i->buf[total][i->slot].valid |= TSLIB_MT_VALID_TOOL;
+@@ -790,7 +804,8 @@ static int ts_input_read_mt(struct tslib_module_info *inf,
+ 					break;
+ 				case ABS_MT_TOOL_TYPE:
+ 					i->buf[total][i->slot].tool_type = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 					/* for future use
+ 					 * i->buf[total][i->slot].valid |= TSLIB_MT_VALID_TOOL;
+@@ -798,12 +813,14 @@ static int ts_input_read_mt(struct tslib_module_info *inf,
+ 					break;
+ 				case ABS_MT_ORIENTATION:
+ 					i->buf[total][i->slot].orientation = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 					break;
+ 				case ABS_MT_DISTANCE:
+ 					i->buf[total][i->slot].distance = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 
+ 					if (i->special_device == EGALAX_VERSION_210) {
+@@ -816,34 +833,40 @@ static int ts_input_read_mt(struct tslib_module_info *inf,
+ 					break;
+ 				case ABS_MT_BLOB_ID:
+ 					i->buf[total][i->slot].blob_id = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 					break;
+ 				case ABS_MT_TOUCH_MAJOR:
+ 					i->buf[total][i->slot].touch_major = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 					if (i->ev[it].value == 0)
+ 						i->buf[total][i->slot].pressure = 0;
+ 					break;
+ 				case ABS_MT_WIDTH_MAJOR:
+ 					i->buf[total][i->slot].width_major = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 					break;
+ 				case ABS_MT_TOUCH_MINOR:
+ 					i->buf[total][i->slot].touch_minor = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 					break;
+ 				case ABS_MT_WIDTH_MINOR:
+ 					i->buf[total][i->slot].width_minor = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 					break;
+ 				case ABS_MT_TRACKING_ID:
+ 					i->buf[total][i->slot].tracking_id = i->ev[it].value;
+-					i->buf[total][i->slot].tv = i->ev[it].time;
++					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
++					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;
+ 					i->buf[total][i->slot].valid |= TSLIB_MT_VALID;
+ 					if (i->ev[it].value == -1)
+ 						i->buf[total][i->slot].pressure = 0;
+diff --git a/tools/ts_uinput.c b/tools/ts_uinput.c
+index 6ca4c3d..1832a07 100644
+--- a/tools/ts_uinput.c
++++ b/tools/ts_uinput.c
+@@ -170,14 +170,16 @@ static int send_touch_events(struct data_t *data, struct ts_sample_mt **s,
+ 				continue;
+ 
+ 			if (s[j][i].pen_down == 1) {
+-				data->ev[c].time = s[j][i].tv;
++				data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++				data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 				data->ev[c].type = EV_KEY;
+ 				data->ev[c].code = BTN_TOUCH;
+ 				data->ev[c].value = s[j][i].pen_down;
+ 				c++;
+ 			}
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_SLOT;
+ 			data->ev[c].value = s[j][i].slot;
+@@ -190,111 +192,129 @@ static int send_touch_events(struct data_t *data, struct ts_sample_mt **s,
+ 			 * we should use slot 1 and so on.
+ 			 */
+ 			if (i == 0) {
+-				data->ev[c].time = s[j][i].tv;
++				data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++				data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 				data->ev[c].type = EV_ABS;
+ 				data->ev[c].code = ABS_X;
+ 				data->ev[c].value = s[j][i].x;
+ 				c++;
+ 
+-				data->ev[c].time = s[j][i].tv;
++				data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++				data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 				data->ev[c].type = EV_ABS;
+ 				data->ev[c].code = ABS_Y;
+ 				data->ev[c].value = s[j][i].y;
+ 				c++;
+ 
+-				data->ev[c].time = s[j][i].tv;
++				data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++				data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 				data->ev[c].type = EV_ABS;
+ 				data->ev[c].code = ABS_PRESSURE;
+ 				data->ev[c].value = s[j][i].pressure;
+ 				c++;
+ 			}
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_POSITION_X;
+ 			data->ev[c].value = s[j][i].x;
+ 			c++;
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_POSITION_Y;
+ 			data->ev[c].value = s[j][i].y;
+ 			c++;
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_PRESSURE;
+ 			data->ev[c].value = s[j][i].pressure;
+ 			c++;
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_TOUCH_MAJOR;
+ 			data->ev[c].value = s[j][i].touch_major;
+ 			c++;
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_WIDTH_MAJOR;
+ 			data->ev[c].value = s[j][i].width_major;
+ 			c++;
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_TOUCH_MINOR;
+ 			data->ev[c].value = s[j][i].touch_minor;
+ 			c++;
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_WIDTH_MINOR;
+ 			data->ev[c].value = s[j][i].width_minor;
+ 			c++;
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_TOOL_TYPE;
+ 			data->ev[c].value = s[j][i].tool_type;
+ 			c++;
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_TOOL_X;
+ 			data->ev[c].value = s[j][i].tool_x;
+ 			c++;
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_TOOL_Y;
+ 			data->ev[c].value = s[j][i].tool_y;
+ 			c++;
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_ORIENTATION;
+ 			data->ev[c].value = s[j][i].orientation;
+ 			c++;
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_DISTANCE;
+ 			data->ev[c].value = s[j][i].distance;
+ 			c++;
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_BLOB_ID;
+ 			data->ev[c].value = s[j][i].blob_id;
+ 			c++;
+ 
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_ABS;
+ 			data->ev[c].code = ABS_MT_TRACKING_ID;
+ 			data->ev[c].value = s[j][i].tracking_id;
+ 			c++;
+ 
+ 			if (data->mt_type_a == 1) {
+-				data->ev[c].time = s[j][i].tv;
++				data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++				data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 				data->ev[c].type = EV_SYN;
+ 				data->ev[c].code = SYN_MT_REPORT;
+ 				data->ev[c].value = 0;
+@@ -302,7 +322,8 @@ static int send_touch_events(struct data_t *data, struct ts_sample_mt **s,
+ 			}
+ 
+ 			if (s[j][i].pen_down == 0) {
+-				data->ev[c].time = s[j][i].tv;
++				data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++				data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 				data->ev[c].type = EV_KEY;
+ 				data->ev[c].code = BTN_TOUCH;
+ 				data->ev[c].value = s[j][i].pen_down;
+@@ -312,7 +333,8 @@ static int send_touch_events(struct data_t *data, struct ts_sample_mt **s,
+ 		}
+ 
+ 		if (c > 0) {
+-			data->ev[c].time = s[j][i].tv;
++			data->ev[c].input_event_sec = s[j][i].tv.tv_sec;
++			data->ev[c].input_event_usec = s[j][i].tv.tv_usec;
+ 			data->ev[c].type = EV_SYN;
+ 			data->ev[c].code = SYN_REPORT;
+ 			data->ev[c].value = 0;
+-- 
+2.24.0
+

--- a/recipes-graphics/tslib/tslib/ts.conf
+++ b/recipes-graphics/tslib/tslib/ts.conf
@@ -1,0 +1,25 @@
+# Uncomment if you wish to use the linux input layer event interface
+module_raw input
+
+# Uncomment if you're using a Sharp Zaurus SL-5500/SL-5000d
+# module_raw collie
+
+# Uncomment if you're using a Sharp Zaurus SL-C700/C750/C760/C860
+# module_raw corgi
+
+# Uncomment if you're using a device with a UCB1200/1300/1400 TS interface
+# module_raw ucb1x00
+
+# Uncomment if you're using an HP iPaq h3600 or similar
+# module_raw h3600
+
+# Uncomment if you're using a Hitachi Webpad
+# module_raw mk712
+
+# Uncomment if you're using an IBM Arctic II
+# module_raw arctic2
+
+module pthres pmin=1
+module variance delta=30
+module dejitter delta=100
+module linear

--- a/recipes-graphics/tslib/tslib/ts.conf
+++ b/recipes-graphics/tslib/tslib/ts.conf
@@ -19,7 +19,11 @@ module_raw input
 # Uncomment if you're using an IBM Arctic II
 # module_raw arctic2
 
-module pthres pmin=1
-module variance delta=30
-module dejitter delta=100
-module linear
+# module pthres pmin=1
+# module variance delta=30
+# module dejitter delta=100
+
+# Force neutral rotation because on openvario the rotation is handled by
+# libinput (see /etc/udev/rules.d/libinput-ts.rules after touchscreen
+# calibration)
+module linear rot=0

--- a/recipes-graphics/tslib/tslib/tslib.sh
+++ b/recipes-graphics/tslib/tslib/tslib.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ -e /dev/input/touchscreen0 ]; then
+    TSLIB_TSDEVICE=/dev/input/touchscreen0
+
+    export TSLIB_TSDEVICE
+fi
+

--- a/recipes-graphics/tslib/tslib_1.21.bb
+++ b/recipes-graphics/tslib/tslib_1.21.bb
@@ -1,0 +1,84 @@
+SUMMARY = "An abstraction layer for touchscreen panel events"
+DESCRIPTION = "Tslib is an abstraction layer for touchscreen panel \
+events, as well as a filter stack for the manipulation of those events. \
+Tslib is generally used on embedded devices to provide a common user \
+space interface to touchscreen functionality."
+HOMEPAGE = "http://tslib.org/"
+
+AUTHOR = "Martin Kepplinger <martink@posteo.de>"
+SECTION = "base"
+LICENSE = "LGPLv2+ & GPLv2+"
+LIC_FILES_CHKSUM = "\
+    file://COPYING;md5=fc178bcd425090939a8b634d1d6a9594 \
+    file://tests/COPYING;md5=a23a74b3f4caf9616230789d94217acb \
+"
+
+SRC_URI = "https://github.com/kergoth/tslib/releases/download/${PV}/tslib-${PV}.tar.xz;downloadfilename=tslib-${PV}.tar.xz \
+           file://0001-Fix-build-on-32bit-arches-with-64bit-time_t.patch \
+           file://0001-Fix-build-error-with-input_event_sec-for-old-kernel.patch \
+           file://ts.conf \
+           file://tslib.sh \
+"
+SRC_URI[md5sum] = "b2b20d3ed520128513f8d3135b42e142"
+SRC_URI[sha256sum] = "d2a57b823ea59e53a3b130eef05dfed1190b857854f886eec764e1ca1957cf56"
+
+UPSTREAM_CHECK_URI = "https://github.com/kergoth/tslib/releases"
+
+inherit autotools pkgconfig
+
+PACKAGECONFIG ??= "debounce dejitter iir linear median pthres skip lowpass invert variance input touchkit waveshare"
+PACKAGECONFIG[debounce] = "--enable-debounce,--disable-debounce"
+PACKAGECONFIG[dejitter] = "--enable-dejitter,--disable-dejitter"
+PACKAGECONFIG[iir] = "--enable-iir,--disable-iir"
+PACKAGECONFIG[linear] = "--enable-linear,--disable-linear"
+PACKAGECONFIG[median] = "--enable-median,--disable-median"
+PACKAGECONFIG[pthres] = "--enable-pthres,--disable-pthres"
+PACKAGECONFIG[skip] = "--enable-skip,--disable-skip"
+PACKAGECONFIG[lowpass] = "--enable-lowpass,--disable-lowpass"
+PACKAGECONFIG[invert] = "--enable-invert,--disable-invert"
+PACKAGECONFIG[variance] = "--enable-variance,--disable-variance"
+PACKAGECONFIG[input] = "--enable-input,--disable-input"
+PACKAGECONFIG[tatung] = "--enable-tatung,--disable-tatung"
+PACKAGECONFIG[touchkit] = "--enable-touchkit,--disable-touchkit"
+PACKAGECONFIG[waveshare] = "--enable-waveshare,--disable-waveshare"
+PACKAGECONFIG[ucb1x00] = "--enable-ucb1x00,--disable-ucb1x00"
+PACKAGECONFIG[mk712] = "--enable-mk712,--disable-mk712"
+PACKAGECONFIG[h3600] = "--enable-h3600,--disable-h3600"
+PACKAGECONFIG[dmc] = "--enable-dmc,--disable-dmc"
+PACKAGECONFIG[linear-h2200] = "--enable-linear-h2200,--disable-linear-h2200"
+PACKAGECONFIG[corgi] = "--enable-corgi,--disable-corgi"
+PACKAGECONFIG[collie] = "--enable-collie,--disable-collie"
+PACKAGECONFIG[arctic2] = "--enable-arctic2,--disable-arctic2"
+PACKAGECONFIG[dmc_dus3000] = "--enable-dmc_dus3000,--disable-dmc_dus3000"
+PACKAGECONFIG[cy8mrln-palmpre] = "--enable-cy8mrln-palmpre,--disable-cy8mrln-palmpre"
+PACKAGECONFIG[galax] = "--enable-galax,--disable-galax"
+PACKAGECONFIG[debug] = "--enable-debug,--disable-debug"
+
+do_install_prepend() {
+    install -m 0644 ${WORKDIR}/ts.conf ${S}/etc/ts.conf
+}
+
+do_install_append() {
+    install -d ${D}${sysconfdir}/profile.d/
+    install -m 0755 ${WORKDIR}/tslib.sh ${D}${sysconfdir}/profile.d/
+}
+
+RPROVIDES_tslib-conf = "libts-0.0-conf"
+
+PACKAGES =+ "tslib-conf tslib-tests tslib-calibrate tslib-uinput"
+DEBIAN_NOAUTONAME_tslib-conf = "1"
+DEBIAN_NOAUTONAME_tslib-tests = "1"
+DEBIAN_NOAUTONAME_tslib-calibrate = "1"
+DEBIAN_NOAUTONAME_tslib-uinput = "1"
+
+RDEPENDS_${PN} = "tslib-conf"
+RRECOMMENDS_${PN} = "pointercal"
+
+FILES_${PN}-dev += "${libdir}/ts/*.la"
+FILES_tslib-conf = "${sysconfdir}/ts.conf ${sysconfdir}/profile.d/tslib.sh ${datadir}/tslib"
+FILES_${PN} = "${libdir}/*.so.* ${libdir}/ts/*.so*"
+FILES_tslib-calibrate += "${bindir}/ts_calibrate"
+FILES_tslib-uinput += "${bindir}/ts_uinput"
+
+FILES_tslib-tests = "${bindir}/ts_harvest ${bindir}/ts_print ${bindir}/ts_print_raw ${bindir}/ts_print_mt \
+                     ${bindir}/ts_test ${bindir}/ts_test_mt ${bindir}/ts_verify ${bindir}/ts_finddev ${bindir}/ts_conf"

--- a/recipes-support/ovmenu-ng-autostart/ovmenu-ng-autostart/.profile
+++ b/recipes-support/ovmenu-ng-autostart/ovmenu-ng-autostart/.profile
@@ -7,8 +7,6 @@ fi
 # path set by /etc/profile
 # export PATH
 
-export TSLIB_TSDEVICE=/dev/input/event5
-
 if ! [ "$(pidof ovmenu-ng.sh)" ]
 then
   /opt/bin/ovmenu-ng.sh

--- a/recipes-support/tslib_support/files/sunxi4-ts.rules
+++ b/recipes-support/tslib_support/files/sunxi4-ts.rules
@@ -1,1 +1,1 @@
-ACTION=="add|change", KERNEL=="event[0-9]*", ENV{ID_PATH_TAG}=="platform-1c25000_rtp", ENV{LIBINPUT_IGNORE_DEVICE}="1" SYMLINK+="input/touchscreen0"
+ACTION=="add|change", KERNEL=="event[0-9]*", ENV{ID_PATH_TAG}=="platform-1c25000_rtp", ENV{LIBINPUT_IGNORE_DEVICE}="1" ENV{SYSTEMD_WANTS}+="ts_uinput.service" SYMLINK+="input/touchscreen0" TAG+="systemd"

--- a/recipes-support/tslib_support/files/sunxi4-ts.rules
+++ b/recipes-support/tslib_support/files/sunxi4-ts.rules
@@ -1,1 +1,1 @@
-ACTION=="add|change", KERNEL=="event[0-9]*", ENV{ID_PATH_TAG}=="platform-1c25000_rtp", ENV{LIBINPUT_IGNORE_DEVICE}="1"
+ACTION=="add|change", KERNEL=="event[0-9]*", ENV{ID_PATH_TAG}=="platform-1c25000_rtp", ENV{LIBINPUT_IGNORE_DEVICE}="1" SYMLINK+="input/touchscreen0"

--- a/recipes-support/tslib_support/files/ts.env
+++ b/recipes-support/tslib_support/files/ts.env
@@ -1,1 +1,1 @@
-TSLIB_TSDEVICE=/dev/input/event5
+TSLIB_TSDEVICE=/dev/input/touchscreen0

--- a/recipes-support/tslib_support/files/ts_uinput.service
+++ b/recipes-support/tslib_support/files/ts_uinput.service
@@ -1,12 +1,8 @@
 [Unit]
 Description=touchscreen input
-After=dev-input-ts.device
 RequiresMountsFor=/etc/ts.env
 
 [Service]
 Type=forking
 EnvironmentFile=/etc/ts.env
 ExecStart=/usr/bin/ts_uinput -d
-
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
This fixes support for touchscreens.

The basic approach here is to use libinput to handle screen rotation, because tslib own rotation support doesn't work well for some reason. We force tslib rotation to be 0 (newtral) for `ts_uinput` service, and rotate the screen using `LIBINPUT_CALIBRATION_MATRIX` variable for udev devices.

This also gives touchscreen a permanent device path: `/dev/input/touchscreen0` for easier discovery.

Touchscreen works in all 4 rotation directions (AFAIU, it used to work only in 2 on old images). 

Fixes #17.