### PR TITLE
Flush filesystem write-cache after key write operations

### DIFF
--- a/recipes-apps/ovmenu-ng-skripts/files/ov-calibrate-ts.sh
+++ b/recipes-apps/ovmenu-ng-skripts/files/ov-calibrate-ts.sh
@@ -18,3 +18,5 @@ udevadm trigger
 
 echo Restart ts_uinput
 systemctl restart ts_uinput
+
+sync

--- a/recipes-apps/ovmenu-ng-skripts/files/update-maps.sh
+++ b/recipes-apps/ovmenu-ng-skripts/files/update-maps.sh
@@ -20,6 +20,6 @@ else
         done
 fi
 
-
+sync
 umount /dev/sda1
 echo "Done !!"

--- a/recipes-apps/ovmenu-ng-skripts/files/upload-xcsoar.sh
+++ b/recipes-apps/ovmenu-ng-skripts/files/upload-xcsoar.sh
@@ -11,5 +11,6 @@ else
         done
 fi
 echo "Umount Stick ..."
+sync
 umount /dev/sda1
 echo "Done !!"

--- a/recipes-apps/ovmenu-ng/files/openvario-43-rgb/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-43-rgb/ovmenu-ng.sh
@@ -181,6 +181,7 @@ function submenu_xcsoar_lang() {
 
 		# update config
 		sed -i 's/^XCSOAR_LANG=.*/XCSOAR_LANG='$menuitem'/' /opt/conf/ov-xcsoar.conf
+		sync
 		dialog --msgbox "New Setting saved !!\n A Reboot is required !!!" 10 50	
 	else
 		dialog --backtitle "OpenVario" \
@@ -259,6 +260,7 @@ function update_system() {
 	response=$?
 	case $response in
 		0) opkg upgrade &>/tmp/tail.$$
+		sync
 		dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
 		;;
 	esac
@@ -296,6 +298,7 @@ function calibrate_sensors() {
 		esac
 		echo "Please run sensorcal again !!!" > /tmp/tail.$$
 	fi
+	sync
 	dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
 	systemctl start sensord
 }
@@ -341,6 +344,7 @@ function start_xcsoar() {
 	else
 		LANG=$XCSOAR_LANG /opt/XCSoar/bin/xcsoar -fly -480x272
 	fi
+	sync
 }
 
 function yesno_exit(){

--- a/recipes-apps/ovmenu-ng/files/openvario-57-lvds/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-57-lvds/ovmenu-ng.sh
@@ -181,6 +181,7 @@ function submenu_xcsoar_lang() {
 
 		# update config
 		sed -i 's/^XCSOAR_LANG=.*/XCSOAR_LANG='$menuitem'/' /opt/conf/ov-xcsoar.conf
+		sync
 		dialog --msgbox "New Setting saved !!\n A Reboot is required !!!" 10 50	
 	else
 		dialog --backtitle "OpenVario" \
@@ -259,6 +260,7 @@ function update_system() {
 	response=$?
 	case $response in
 		0) opkg upgrade &>/tmp/tail.$$
+		sync
 		dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
 		;;
 	esac
@@ -296,6 +298,7 @@ function calibrate_sensors() {
 		esac
 		echo "Please run sensorcal again !!!" > /tmp/tail.$$
 	fi
+	sync
 	dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
 	systemctl start sensord
 }
@@ -342,6 +345,7 @@ function start_xcsoar() {
 	else
 		LANG=$XCSOAR_LANG /opt/XCSoar/bin/xcsoar -fly -640x480
 	fi
+	sync
 }
 
 function yesno_exit(){

--- a/recipes-apps/ovmenu-ng/files/openvario-7-CH070/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-7-CH070/ovmenu-ng.sh
@@ -181,6 +181,7 @@ function submenu_xcsoar_lang() {
 
 		# update config
 		sed -i 's/^XCSOAR_LANG=.*/XCSOAR_LANG='$menuitem'/' /opt/conf/ov-xcsoar.conf
+		sync
 		dialog --msgbox "New Setting saved !!\n A Reboot is required !!!" 10 50	
 	else
 		dialog --backtitle "OpenVario" \
@@ -259,6 +260,7 @@ function update_system() {
 	response=$?
 	case $response in
 		0) opkg upgrade &>/tmp/tail.$$
+		sync
 		dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
 		;;
 	esac
@@ -296,6 +298,7 @@ function calibrate_sensors() {
 		esac
 		echo "Please run sensorcal again !!!" > /tmp/tail.$$
 	fi
+	sync
 	dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
 	systemctl start sensord
 }
@@ -341,6 +344,7 @@ function start_xcsoar() {
 	else
 		LANG=$XCSOAR_LANG /opt/XCSoar/bin/xcsoar -fly -800x480
 	fi
+	sync
 }
 
 function yesno_exit(){

--- a/recipes-apps/ovmenu-ng/files/openvario-7-PQ070/ovmenu-ng.sh
+++ b/recipes-apps/ovmenu-ng/files/openvario-7-PQ070/ovmenu-ng.sh
@@ -181,6 +181,7 @@ function submenu_xcsoar_lang() {
 
 		# update config
 		sed -i 's/^XCSOAR_LANG=.*/XCSOAR_LANG='$menuitem'/' /opt/conf/ov-xcsoar.conf
+		sync
 		dialog --msgbox "New Setting saved !!\n A Reboot is required !!!" 10 50	
 	else
 		dialog --backtitle "OpenVario" \
@@ -259,6 +260,7 @@ function update_system() {
 	response=$?
 	case $response in
 		0) opkg upgrade &>/tmp/tail.$$
+		sync
 		dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
 		;;
 	esac
@@ -296,6 +298,7 @@ function calibrate_sensors() {
 		esac
 		echo "Please run sensorcal again !!!" > /tmp/tail.$$
 	fi
+	sync
 	dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
 	systemctl start sensord
 }
@@ -341,6 +344,7 @@ function start_xcsoar() {
 	else
 		LANG=$XCSOAR_LANG /opt/XCSoar/bin/xcsoar -fly -1024x600; 
 	fi
+	sync
 }
 
 function yesno_exit(){


### PR DESCRIPTION
Force write-cache flushing to avoid losing data when user turns off
power without shutting down the device gracefully.

Fixes #90.