### PR TITLE
Disable touch-screen auto-detection

### DIFF
--- a/recipes-apps/xcsoar/files/0007-Disable-touch-screen-auto-detection.patch
+++ b/recipes-apps/xcsoar/files/0007-Disable-touch-screen-auto-detection.patch
@@ -1,0 +1,30 @@
+From 9d515d154921e0c08337a50c8c616a327310d4c2 Mon Sep 17 00:00:00 2001
+From: Andrey Lebedev <andrey@lebedev.lt>
+Date: Sun, 5 Jul 2020 22:58:38 +0300
+Subject: [PATCH] Disable touch-screen auto-detection
+
+When touch screen is detected, XCSoar renders larger buttons and other
+screen controls. Larger control size is more preferrable for Openvario
+even on machines with no touch screen is installed: it is easier to
+click larger controls with the stick control and labels acually fit the
+buttons with the larger font sizes.
+---
+ src/Event/Poll/LibInput/LibInputHandler.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Event/Poll/LibInput/LibInputHandler.hpp b/src/Event/Poll/LibInput/LibInputHandler.hpp
+index 0ca1d8f512..b9eeb3e724 100644
+--- a/src/Event/Poll/LibInput/LibInputHandler.hpp
++++ b/src/Event/Poll/LibInput/LibInputHandler.hpp
+@@ -53,7 +53,7 @@ class LibInputHandler final {
+   /**
+    * The number of pointer input devices, touch screens ans keyboards.
+    */
+-  unsigned n_pointers = 0, n_touch_screens = 0, n_keyboards = 0;
++  unsigned n_pointers = 0, n_touch_screens = 1, n_keyboards = 0;
+ 
+ public:
+   explicit LibInputHandler(boost::asio::io_context &io_context,
+-- 
+2.25.1
+

--- a/recipes-apps/xcsoar/xcsoar-testing_git.bb
+++ b/recipes-apps/xcsoar/xcsoar-testing_git.bb
@@ -50,6 +50,7 @@ SRC_URI = " \
 	file://0001-Disable-warnings-as-errors.patch \
 	file://0001_no_version_lua.patch \
 	file://0001-avoid-tail-cut.patch \
+	file://0007-Disable-touch-screen-auto-detection.patch \
 	file://ov-xcsoar.conf \
 "
 

--- a/recipes-apps/xcsoar/xcsoar_6.8.15.bb
+++ b/recipes-apps/xcsoar/xcsoar_6.8.15.bb
@@ -47,6 +47,7 @@ SRC_URI = " \
     file://0001-Disable-warnings-as-errors.patch \
     file://0001-avoid-tail-cut.patch \
     file://0006-Include-header-containing-errno-for-6.8.patch \
+    file://0007-Disable-touch-screen-auto-detection.patch \
     file://ov-xcsoar.conf \
 "
 


### PR DESCRIPTION
When touch screen is detected, XCSoar renders larger buttons and other screen controls. Larger control size is more preferable for Openvario even on machines with no touch screen is installed: it is easier to click larger controls with the stick control and 
labels actually fit the buttons with the larger font sizes.

Before / After:
![IMG_20200706_131914](https://user-images.githubusercontent.com/59499/86584231-3f35b600-bf8d-11ea-80a1-6ed4e96ea6b7.jpg) ![IMG_20200706_131841](https://user-images.githubusercontent.com/59499/86584215-3cd35c00-bf8d-11ea-8c5f-1bd5c5468a48.jpg)
