### PR TITLE
Explicitly compile xcsoar-6.8 with libinput support

### DIFF
--- a/recipes-apps/xcsoar/xcsoar_6.8.16.bb
+++ b/recipes-apps/xcsoar/xcsoar_6.8.16.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "www.xcsoar.org"
 LICENSE = "GPL-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/${LICENSE};md5=801f80980d171dd6425610833a22dbe6"
 SECTION = "base/app"
-PR="r0"
+PR="r1"
 RCONFLICTS_${PN}="xcsoar-testing"
 
 DEPENDS = " \
@@ -68,7 +68,7 @@ do_compile() {
     echo '${WORKDIR}'
     cd ${WORKDIR}/git
     # export CPATH=${D}/usr/include
-    make -j$(nproc) DEBUG=n DEBUG_GLIBCXX=n ENABLE_MESA_KMS=y GEOTIFF=n
+    make -j$(nproc) DEBUG=n DEBUG_GLIBCXX=n ENABLE_MESA_KMS=y USE_LIBINPUT=y GEOTIFF=n
 }
 
 do_install() {


### PR DESCRIPTION
XCSoar-6.8.x (differently from 7.x) does not compile with `libinput` by default. `libinput` is needed for touchscreen support.

Fixes #17 