### PR TITLE
Better distro codename

### DIFF
--- a/conf/distro/ovlinux.conf
+++ b/conf/distro/ovlinux.conf
@@ -4,7 +4,7 @@ DISTRO = "ovlinux"
 DISTRO_NAME = "OpenVario Linux (for OpenVario Flight Computer)"
 DISTRO_VERSION = "${@time.strftime('%y%j',time.gmtime())}"
 #DISTRO_VERSION = "${DATE}"
-DISTRO_CODENAME = "ov-thud"
+DISTRO_CODENAME = "ov-warrior"
 SDK_VENDOR = "-ovlinuxsdk"
 SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
 


### PR DESCRIPTION
Since distro is based on warrior, let's call it `ov-warrior`.