### PR TITLE
Turn off the display backlight on shutdown

### DIFF
--- a/recipes-kernel/linux/linux-mainline/0002-Allow-to-set-duty-cycle-before-turning-off-the-PWM.patch
+++ b/recipes-kernel/linux/linux-mainline/0002-Allow-to-set-duty-cycle-before-turning-off-the-PWM.patch
@@ -1,0 +1,28 @@
+From 3447fd8c8891a7ff064f45d3ee364fed0cf77c03 Mon Sep 17 00:00:00 2001
+From: Andrey Lebedev <andrey@lebedev.lt>
+Date: Wed, 2 Sep 2020 22:21:19 +0300
+Subject: [PATCH] Allow to set duty cycle before turning off the PWM
+
+This fixes the problem of screen backlight staying on after system
+is shut down.
+---
+ drivers/pwm/pwm-sun4i.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/drivers/pwm/pwm-sun4i.c b/drivers/pwm/pwm-sun4i.c
+index 5c677c563349..4b0b9aed9bb9 100644
+--- a/drivers/pwm/pwm-sun4i.c
++++ b/drivers/pwm/pwm-sun4i.c
+@@ -296,9 +296,6 @@ static int sun4i_pwm_apply(struct pwm_chip *chip, struct pwm_device *pwm,
+ 
+ 	if (state->enabled) {
+ 		ctrl |= BIT_CH(PWM_EN, pwm->hwpwm);
+-	} else {
+-		ctrl &= ~BIT_CH(PWM_EN, pwm->hwpwm);
+-		ctrl &= ~BIT_CH(PWM_CLK_GATING, pwm->hwpwm);
+ 	}
+ 
+ 	sun4i_pwm_writel(sun4i_pwm, ctrl, PWM_CTRL_REG);
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-mainline_5.7.bbappend
+++ b/recipes-kernel/linux/linux-mainline_5.7.bbappend
@@ -5,6 +5,7 @@ SRC_URI += " \
     file://${KERNEL_DEVICETREE_SOURCE} \
     file://lima.conf \
     file://0001-drm-lima-Expose-job_hang_limit-module-parameter.patch \
+    file://0002-Allow-to-set-duty-cycle-before-turning-off-the-PWM.patch \
 "
 
 PR = "r0"


### PR DESCRIPTION
This fixes the problem of screen backlight staying on after system
is shut down.

Fixes #103 