### PR TITLE
Fix xcsoar build on testing image

### DIFF
--- a/recipes-apps/xcsoar/files/0007-Disable-touch-screen-auto-detection.patch
+++ b/recipes-apps/xcsoar/files/0007-Disable-touch-screen-auto-detection.patch
@@ -9,13 +9,13 @@ even on machines with no touch screen is installed: it is easier to
 click larger controls with the stick control and labels acually fit the
 buttons with the larger font sizes.
 ---
- src/Event/Poll/LibInput/LibInputHandler.hpp | 2 +-
+ src/event/poll/libinput/LibInputHandler.hpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/src/Event/Poll/LibInput/LibInputHandler.hpp b/src/Event/Poll/LibInput/LibInputHandler.hpp
+diff --git a/src/event/poll/libinput/LibInputHandler.hpp b/src/event/poll/libinput/LibInputHandler.hpp
 index 0ca1d8f512..b9eeb3e724 100644
---- a/src/Event/Poll/LibInput/LibInputHandler.hpp
-+++ b/src/Event/Poll/LibInput/LibInputHandler.hpp
+--- a/src/event/poll/libinput/LibInputHandler.hpp
++++ b/src/event/poll/libinput/LibInputHandler.hpp
 @@ -53,7 +53,7 @@ class LibInputHandler final {
    /**
     * The number of pointer input devices, touch screens ans keyboards.


### PR DESCRIPTION
XCSoar did a massive source tree rename, making an openvario patch unapplyable. Fix the paths in the patch.