### PR TITLE
Fix -testing image build

### DIFF
--- a/recipes-apps/xcsoar/xcsoar-testing_git.bb
+++ b/recipes-apps/xcsoar/xcsoar-testing_git.bb
@@ -31,6 +31,7 @@ DEPENDS = "	\
 		virtual/libgles2 \
 		alsa-lib \
 		libsodium \
+		c-ares \
 "
 
 RDEPENDS_${PN} = "\


### PR DESCRIPTION
Newest xcsoar requires a new library - c-ares (for async DNS
name resolution). Include it into xcsoar-testing build recipe.