### PR TITLE
Disable SPI, enable ttys4 on UART6

### DIFF
--- a/recipes-kernel/linux/linux-mainline/openvario-7-AM070-DS2.dts
+++ b/recipes-kernel/linux/linux-mainline/openvario-7-AM070-DS2.dts
@@ -27,10 +27,3 @@
 &uart5 {
     pinctrl-0 = <&uart5_pi_pins>;
 };
-
-// UART6 on Schematic
-&uart6 {
-    pinctrl-names = "default";
-    pinctrl-0 = <&uart6_pi_pins>;
-    status = "okay";
-};

--- a/recipes-kernel/linux/linux-mainline/openvario-7-CH070-DS2.dts
+++ b/recipes-kernel/linux/linux-mainline/openvario-7-CH070-DS2.dts
@@ -27,10 +27,3 @@
 &uart5 {
     pinctrl-0 = <&uart5_pi_pins>;
 };
-
-// UART6 on Schematic
-&uart6 {
-    pinctrl-names = "default";
-    pinctrl-0 = <&uart6_pi_pins>;
-    status = "okay";
-};

--- a/recipes-kernel/linux/linux-mainline/openvario-common.dts
+++ b/recipes-kernel/linux/linux-mainline/openvario-common.dts
@@ -101,6 +101,13 @@
 	status = "okay";
 };
 
+// UART6 on Schematic - enabling this removes SPI functionality in order to enable 4th IGC port usage
+&uart6 {
+    pinctrl-names = "default";
+    pinctrl-0 = <&uart6_pi_pins>;
+    status = "okay";
+};
+
 &rtp {
 	allwinner,ts-attached;
 	allwinner,tp-sensitive-adjust = <0>;


### PR DESCRIPTION
In the current state, the first OpenVario RJ45 socket is currently used as ttyS0, a Linux serial console for debugging, and it is not recommended to connect an IGC-compatible device to it. This means that only 3 IGC-compatible devices can connect to OpenVario.

This modification assigns Cubieboard pins which are currently designated as SPI pins to work as UART pins, so that a fourth IGC-compatible device can be connected to OpenVario using the hardware modification described below. 

As-is:
At present, pins 46 and 48 of Cubieboard connector Cubie1 (U14 in the Cubieboard datasheet) are used for SPI0-MOSI and SPI0-MISO. These are taken to the Sensorboard via the UEXT connector, but are then unused, as **no devices currently interface to OpenVario through SPI**.


To be:
Pins 46 and 48 are assigned to UART6, a fourth IGC-comaptible device can be connected to OpenVario, provided that the following hardware modifications are performed (referenced to the original OpenVario adapterboard):
- Remove the two wires running from the Rx and Tx pins on the Cubieboard to the UART0 connector on the adapterboard _(this breaks the ttyS0 debug feed to the first RJ45 socket)_ 
- Link pin SPI0-MOSI on adapterboard UEXT connector with pin UART1-TX on adapterboard UART0 connector _(this connects UART6 TX to the first RJ45 socket)_
- Link pin SPI0-MISO on adapterboard UEXT connector with pin UART1-RX on adapterboard UART0 connector _(this connects UART6 TX to the first RJ45 socket)_

The IGC device will then be accessible in XCsoar under ttyS4