### PR TITLE
Fix devicetree syntax error

### DIFF
--- a/recipes-kernel/linux/linux-mainline/openvario-common.dts
+++ b/recipes-kernel/linux/linux-mainline/openvario-common.dts
@@ -103,9 +103,9 @@
 
 // UART6 on Schematic - enabling this removes SPI functionality in order to enable 4th IGC port usage
 &uart6 {
-    pinctrl-names = "default";
-    pinctrl-0 = <&uart6_pi_pins>;
-    status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart6_pi_pins>;
+	status = "okay";
 };
 
 &rtp {


### PR DESCRIPTION
The error was introduced in #122. For whatever reason the code was
indented using NO-BREAK SPACE characters.