### PR TITLE
Fix download-all.sh

### DIFF
--- a/recipes-apps/ovmenu-ng-skripts/files/download-all.sh
+++ b/recipes-apps/ovmenu-ng-skripts/files/download-all.sh
@@ -10,7 +10,7 @@ fi
 if [ -z "$(ls $DOWNLOAD_PATH/* 2>/dev/null)" ]; then
         echo "No files found !!!"
 else
-        cp -rv "$SDOWNLOAD_PATH" "$USB_PATH"
+        cp -rv "$DOWNLOAD_PATH" "$USB_PATH"
 fi
 
 echo "Umount Stick ..."

--- a/recipes-apps/ovmenu-ng-skripts/files/download-all.sh
+++ b/recipes-apps/ovmenu-ng-skripts/files/download-all.sh
@@ -10,7 +10,7 @@ fi
 if [ -z "$(ls $DOWNLOAD_PATH/* 2>/dev/null)" ]; then
         echo "No files found !!!"
 else
-        cp -rv "$DOWNLOAD_PATH" "$USB_PATH"
+        cp -rv "$DOWNLOAD_PATH/*" "$USB_PATH"
 fi
 
 echo "Umount Stick ..."

--- a/recipes-apps/ovmenu-ng-skripts/files/download-all.sh
+++ b/recipes-apps/ovmenu-ng-skripts/files/download-all.sh
@@ -4,7 +4,7 @@ USB_PATH="/usb/usbstick/openvario/download/xcsoar"
 DOWNLOAD_PATH="/home/root/.xcsoar"
 
 if [ ! -d "$USB_PATH" ]; then
-	mkdir "$USB_PATH"
+	mkdir -p "$USB_PATH"
 fi
 
 if [ -z "$(ls $DOWNLOAD_PATH/* 2>/dev/null)" ]; then


### PR DESCRIPTION
Tested on a Stefly 5.7" OpenVario.

When you select the Download option in the ov-menu, no files are transferred to the USB stick.
This is for two reasons:
 - A typo in a shell variable
 - A failing mkdir command

This PR fixes both, and the contents of the .xcsoar directory are transferred to the stick.
Note that this takes quite some time as also the map files are copied.