### PR TITLE
Add additional wifi drivers

### DIFF
--- a/recipes-core/images/openvario-base-image.bb
+++ b/recipes-core/images/openvario-base-image.bb
@@ -13,9 +13,8 @@ COMMON_WIFI_FIRMWARE_PACKAGES = " \
     linux-firmware-ralink \
     linux-firmware-rtl8168 \
     linux-firmware-rtl8188 \
-    linux-firmware-rtl8192ce \
-    linux-firmware-rtl8192cu \
-    linux-firmware-rtl8192su \
+    linux-firmware-rtl8192 \
+    linux-firmware-rtl8712 \
     linux-firmware-rtl8723 \
     linux-firmware-rtl8821 \
 "

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,0 +1,16 @@
+
+PACKAGES =+ "${PN}-rtl8192 "
+LICENSE_${PN}-rtl8192 = "Firmware-rtlwifi_firmware"
+FILES_${PN}-rtl8192 = " ${nonarch_base_libdir}/firmware/rtlwifi/rtl8192*.bin "
+RDEPENDS_${PN}-rtl8192 += "${PN}-rtl-license"
+
+PACKAGES =+ "${PN}-rtl8712 "
+LICENSE_${PN}-rtl8712 = "Firmware-rtlwifi_firmware"
+FILES_${PN}-rtl8712 = " ${nonarch_base_libdir}/firmware/rtlwifi/rtl8712*.bin "
+RDEPENDS_${PN}-rtl8712 += "${PN}-rtl-license"
+
+FILES_${PN}-rtl8192ce = " "
+FILES_${PN}-rtl8192cu = " "
+FILES_${PN}-rtl8192su = " "
+
+


### PR DESCRIPTION
Here it should be enabled some current (wifi) drivers. On my desk is working:
* a D-Link wifi stick (with a ralink driver)
* a TP-Link wifi stick TL-WN823N (with a rtl8192eu_nic driver)
* a DIGITUS USB3.0 Ethernet Adapter (USB to LAN)
* a Profilec PL2303 USB-Seriell adapter
In the folder /lib/firmware, /lib/firmware/rtl_nic and /lib/firmware/rtlwifi there are a lot of other drivers available (f.e. rtl8188, rtl8712, rtl8723, rtl8821 and many more).
