### PR TITLE
fix xcsoar builds

### DIFF
--- a/recipes-apps/xcsoar/xcsoar-testing_git.bb
+++ b/recipes-apps/xcsoar/xcsoar-testing_git.bb
@@ -44,14 +44,12 @@ LC_LOCALE_PATH = "/usr/share/locale"
 
 SRCREV_pn-xcsoar-testing = "${AUTOREV}" 
 
-SRC_URI = " \
-	git://github.com/XCSoar/XCSoar.git;protocol=git;branch=master \
-	file://0001_no_version_lua.patch \
-	file://0001-avoid-tail-cut.patch \
-	file://0005-Adapted-toolchain-prefixes-for-cross-compile.patch \
-	file://0007-Disable-touch-screen-auto-detection.patch \
-	file://ov-xcsoar.conf \
-"
+SRC_URI = "git://github.com/XCSoar/XCSoar.git;protocol=git;branch=master \
+           file://ov-xcsoar.conf"
+
+SRC_URI_append = " file://0001-avoid-tail-cut.patch"
+SRC_URI_append = " file://0005-Adapted-toolchain-prefixes-for-cross-compile.patch"
+SRC_URI_append = " file://0007-Disable-touch-screen-auto-detection.patch"
 
 inherit pkgconfig update-alternatives
 

--- a/recipes-apps/xcsoar/xcsoar_7.21.bb
+++ b/recipes-apps/xcsoar/xcsoar_7.21.bb
@@ -45,9 +45,9 @@ LC_LOCALE_PATH = "/usr/share/locale"
 SRC_URI = "git://github.com/XCSoar/XCSoar.git;protocol=git;tag=v${PV} \
            file://ov-xcsoar.conf"
 
-SRC_URI_append = "file://0001-avoid-tail-cut.patch"
-SRC_URI_append = "file://0005-Adapted-toolchain-prefixes-for-cross-compile.patch"
-SRC_URI_append = "file://0007-Disable-touch-screen-auto-detection.patch"
+SRC_URI_append = " file://0001-avoid-tail-cut.patch"
+SRC_URI_append = " file://0005-Adapted-toolchain-prefixes-for-cross-compile.patch"
+SRC_URI_append = " file://0007-Disable-touch-screen-auto-detection.patch"
 
 inherit pkgconfig update-alternatives
 


### PR DESCRIPTION
XCSoar does not build anymore after the last set of merges (missing patch for testing, wrong format for production build). Those changes fix this.