### PR TITLE
fix for Rotary encoder

### DIFF
--- a/recipes-apps/xcsoar/files/0001-HasNoPointer.patch
+++ b/recipes-apps/xcsoar/files/0001-HasNoPointer.patch
@@ -1,0 +1,23 @@
+--- a/src/Form/ButtonPanel.cpp
++++ b/src/Form/ButtonPanel.cpp
+@@ -353,7 +353,7 @@ ButtonPanel::KeyPress(unsigned key_code)
+     }
+   }
+ 
+-  if (selected_index >= 0 && !HasPointer()) {
++  if (selected_index >= 0) {
+     if (key_code == KEY_LEFT) {
+       SelectPrevious();
+       return true;
+       
+--- a/src/Form/Button.cpp
++++ b/src/Form/Button.cpp
+@@ -239,7 +239,7 @@ Button::OnPaint(Canvas &canvas)
+ 
+   const bool pressed = down;
+   const bool focused = HasCursorKeys()
+-    ? HasFocus() || (selected && !HasPointer())
++    ? HasFocus() || (selected)
+     : pressed;
+ 
+   renderer->DrawButton(canvas, GetClientRect(),

--- a/recipes-apps/xcsoar/xcsoar-testing_git.bb
+++ b/recipes-apps/xcsoar/xcsoar-testing_git.bb
@@ -50,6 +50,7 @@ SRC_URI = "git://github.com/XCSoar/XCSoar.git;protocol=git;branch=master \
 SRC_URI_append = " file://0001-avoid-tail-cut.patch"
 SRC_URI_append = " file://0005-Adapted-toolchain-prefixes-for-cross-compile.patch"
 SRC_URI_append = " file://0007-Disable-touch-screen-auto-detection.patch"
+SRC_URI_append = " file://0001-HasNoPointer.patch"
 
 inherit pkgconfig update-alternatives
 

--- a/recipes-apps/xcsoar/xcsoar_7.21.bb
+++ b/recipes-apps/xcsoar/xcsoar_7.21.bb
@@ -48,6 +48,7 @@ SRC_URI = "git://github.com/XCSoar/XCSoar.git;protocol=git;tag=v${PV} \
 SRC_URI_append = " file://0001-avoid-tail-cut.patch"
 SRC_URI_append = " file://0005-Adapted-toolchain-prefixes-for-cross-compile.patch"
 SRC_URI_append = " file://0007-Disable-touch-screen-auto-detection.patch"
+SRC_URI_append = " file://0001-HasNoPointer.patch"
 
 inherit pkgconfig update-alternatives
 


### PR DESCRIPTION
The rotary encoder is now working again to control the respective items in the menu. Solves this problem:

https://github.com/Openvario/meta-openvario/issues/89