### PR TITLE
Remove some bloat (unnecessary dependencies and build options)

### DIFF
--- a/conf/distro/ovlinux.conf
+++ b/conf/distro/ovlinux.conf
@@ -30,7 +30,8 @@ POKY_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland vulkan"
 POKY_DEFAULT_EXTRA_RDEPENDS = "packagegroup-core-boot"
 POKY_DEFAULT_EXTRA_RRECOMMENDS = "kernel-module-af-packet"
 
-PACKAGECONFIG_append_pn-wget = " openssl gnutls"
+PACKAGECONFIG:append:pn-wget = " gnutls"
+PACKAGECONFIG:remove:pn-wget = "openssl pcre"
 
 PACKAGECONFIG:remove:pn-alsa-plugins = "samplerate speexdsp"
 

--- a/conf/distro/ovlinux.conf
+++ b/conf/distro/ovlinux.conf
@@ -32,6 +32,8 @@ POKY_DEFAULT_EXTRA_RRECOMMENDS = "kernel-module-af-packet"
 
 PACKAGECONFIG_append_pn-wget = " openssl gnutls"
 
+PACKAGECONFIG:remove:pn-alsa-plugins = "samplerate speexdsp"
+
 PREFERRED_VERSION_linux-yocto ?= "4.18%"
 
 SDK_NAME = "${DISTRO}-${TCLIBC}-${SDK_ARCH}-${IMAGE_BASENAME}-${TUNE_PKGARCH}"

--- a/conf/distro/ovlinux.conf
+++ b/conf/distro/ovlinux.conf
@@ -24,11 +24,18 @@ TARGET_VENDOR = "-ovlinux"
 DISTRO_VERSION[vardepsexclude] = "DATE"
 SDK_VERSION[vardepsexclude] = "DATE"
 
-
 # Override these in poky based distros
-POKY_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland vulkan"
+POKY_DEFAULT_DISTRO_FEATURES = "largefile opengl"
 POKY_DEFAULT_EXTRA_RDEPENDS = "packagegroup-core-boot"
 POKY_DEFAULT_EXTRA_RRECOMMENDS = "kernel-module-af-packet"
+
+PACKAGECONFIG:remove:pn-glibc = "nscd"
+PACKAGECONFIG:remove:pn-systemd = "binfmt hibernate ima localed machined nss-mymachines quotacheck"
+PACKAGECONFIG:remove:pn-connman = "wispr"
+PACKAGECONFIG:remove:pn-curl = "libidn proxy verbose"
+PACKAGECONFIG:remove:pn-bluez5 = "obex-profiles readline a2dp-profiles avrcp-profiles network-profiles hid-profiles hog-profiles deprecated"
+PACKAGECONFIG:remove:pn-glib-2.0 = "libmount"
+SHAREDMIMEDEP:pn-glib-2.0 = ""
 
 PACKAGECONFIG:append:pn-wget = " gnutls"
 PACKAGECONFIG:remove:pn-wget = "openssl pcre"
@@ -45,6 +52,7 @@ DISTRO_EXTRA_RRECOMMENDS += " ${POKY_DEFAULT_EXTRA_RRECOMMENDS}"
 
 DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${DISTRO_FEATURES_LIBC} ${POKY_DEFAULT_DISTRO_FEATURES}"
 DISTRO_FEATURES_append = " systemd"
+DISTRO_FEATURES:remove = "acl argp pcmcia usbgadget xattr nfs zeroconf pci 3g nfc x11"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 
 # Make /var/log dir persistent on the filesystem. By default logs are located

--- a/recipes-apps/xcsoar/xcsoar-testing_git.bb
+++ b/recipes-apps/xcsoar/xcsoar-testing_git.bb
@@ -68,7 +68,7 @@ do_compile() {
 	echo "Making .."
 	echo '${WORKDIR}'
 	cd ${WORKDIR}/git
-	make -j$(nproc) DEBUG=n DEBUG_GLIBCXX=n ENABLE_MESA_KMS=y GEOTIFF=n
+	make -j$(nproc) DEBUG=n DEBUG_GLIBCXX=n ENABLE_MESA_KMS=y GLES2=y GEOTIFF=n
 }
 
 do_install() {

--- a/recipes-apps/xcsoar/xcsoar-testing_git.bb
+++ b/recipes-apps/xcsoar/xcsoar-testing_git.bb
@@ -12,7 +12,7 @@ RCONFLICTS_${PN}="xcsoar"
 DEPENDS = "	\
 		gcc \
 		boost \
-		curlpp \
+		curl \
 		pkgconfig \
 		libxslt-native \
 		librsvg-native \

--- a/recipes-apps/xcsoar/xcsoar_7.21.bb
+++ b/recipes-apps/xcsoar/xcsoar_7.21.bb
@@ -66,7 +66,7 @@ do_compile() {
 	echo "Making .."
 	echo '${WORKDIR}'
 	cd ${WORKDIR}/git
-	make -j$(nproc) DEBUG=n DEBUG_GLIBCXX=n ENABLE_MESA_KMS=y GEOTIFF=n
+	make -j$(nproc) DEBUG=n DEBUG_GLIBCXX=n ENABLE_MESA_KMS=y GLES2=y GEOTIFF=n
 }
 
 do_install() {

--- a/recipes-apps/xcsoar/xcsoar_7.21.bb
+++ b/recipes-apps/xcsoar/xcsoar_7.21.bb
@@ -12,7 +12,7 @@ RCONFLICTS_${PN}="xcsoar-testing"
 DEPENDS = "	\
 		gcc \
 		boost \
-		curlpp \
+		curl \
 		pkgconfig \
 		libxslt-native \
 		librsvg-native \


### PR DESCRIPTION
This reduces the firmware size from 143 MB to 132 MB. A lot more is possible; for example, PulseAudio is responsible for a very long rat tail of dependencies.