### PR TITLE
Cubieboard 1 support

### DIFF
--- a/conf/machine/ov-cubieboard.conf
+++ b/conf/machine/ov-cubieboard.conf
@@ -1,0 +1,13 @@
+# Experimental machine definition for a plain Cubieboard 1 without any
+# additional OpenVario hardware.
+
+DEFAULTTUNE = "cortexa8hf-neon"
+
+PREFERRED_VERSION_linux-mainline = "5.10%"
+
+# use the open source "Lima" Mali GPU driver
+MACHINEOVERRIDES .= ":use-mailine-graphics"
+
+# inherit the meta-sunxi "cubieboard" machine
+require conf/machine/cubieboard.conf
+MACHINEOVERRIDES =. "cubieboard:"

--- a/recipes-apps/ovmenu-ng/files/machine.conf
+++ b/recipes-apps/ovmenu-ng/files/machine.conf
@@ -1,0 +1,2 @@
+# Generic machine configuration file; for this machine, no per-machine
+# configuration exists.

--- a/recipes-bsp/u-boot/files/per_machine.cfg
+++ b/recipes-bsp/u-boot/files/per_machine.cfg
@@ -1,0 +1,2 @@
+# Empty file; for this machine, no per-machine configuration fragment
+# exists.

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -38,7 +38,7 @@ do_compile_append() {
 # Add the files folder to the saerch path:
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI_append = " \
+SRC_URI_append_cubieboard2 = " \
         file://openvario_defconfig \
         file://per_machine.cfg \
         file://openvario.dts \
@@ -58,12 +58,12 @@ SRC_URI_append = " \
         file://0001-Environment-Openvario-mainline.patch \
     "
 
-do_configure_prepend() {
+do_configure_prepend_cubieboard2() {
     cp ${WORKDIR}/openvario_defconfig ${S}/configs/openvario_defconfig
     cp ${WORKDIR}/openvario.dts ${S}/arch/arm/dts/openvario.dts
 }
 
-do_install_append() {
+do_install_append_cubieboard2() {
     if [ -e ${WORKDIR}/ov_recover_0.bmp ] ; then
     install -m 644 -D ${WORKDIR}/ov_*.bmp ${D}/boot
     fi
@@ -73,7 +73,7 @@ do_install_append() {
     fi
 }
 
-do_deploy_append() {
+do_deploy_append_cubieboard2() {
     if [ -e ${WORKDIR}/ov_recover_0.bmp ] ; then
     install -d ${DEPLOYDIR}/pics
         install -m 644 -D ${WORKDIR}/ov_*.bmp ${DEPLOYDIR}/pics


### PR DESCRIPTION
I don't have a Cubieboard 2, only Cubieboard 1, and I don't have an OpenVario, but I want to test OpenVario images. So I thought, why not just build a Cubieboard 1 image? That was very complicated at first, but after a considerable amount of cleanup in the OpenVario layer, adding the Cubiebiard 1 machine configuration was just a few lines.
This draft PR is a work-in-progress dump of my stgit stack with lots of experimental stuff, as a preview of what's to come in proper PRs soon.