### PR TITLE
Experimental XCSoar-based menu

### DIFF
--- a/meta-ov/recipes-apps/xcsoar/files/ovmenu-x.service
+++ b/meta-ov/recipes-apps/xcsoar/files/ovmenu-x.service
@@ -1,0 +1,48 @@
+[Unit]
+Description=XCSoar-based OpenVario Menu
+
+# No getty on tty1
+Conflicts=getty@tty1.service
+Conflicts=ovmenu-ng.service
+
+After=systemd-user-sessions.service plymouth-quit-wait.service getty-pre.target
+After=rc-local.service
+
+# If additional gettys are spawned during boot then we should make
+# sure that this is synchronized before getty.target, even though
+# getty.target didn't actually pull it in.
+Before=getty.target
+IgnoreOnIsolate=yes
+
+# IgnoreOnIsolate causes issues with sulogin, if someone isolates
+# rescue.target or starts rescue.service from multi-user.target or
+# graphical.target.
+Conflicts=rescue.service
+Before=rescue.service
+
+# On systems without virtual consoles, don't start any getty. Note
+# that serial gettys are covered by serial-getty@.service, not this
+# unit.
+ConditionPathExists=/dev/tty0
+
+[Service]
+ExecStart=/usr/bin/OpenVarioMenu
+Type=idle
+Restart=always
+RestartSec=0
+
+Environment=HOME=/home/root
+
+TTYPath=/dev/tty1
+TTYReset=yes
+TTYVHangup=yes
+TTYVTDisallocate=yes
+IgnoreSIGPIPE=no
+SendSIGHUP=yes
+
+StandardInput=tty
+
+Slice=user.slice
+
+[Install]
+WantedBy=getty.target

--- a/meta-ov/recipes-apps/xcsoar/xcsoar-testing_git.bb
+++ b/meta-ov/recipes-apps/xcsoar/xcsoar-testing_git.bb
@@ -7,6 +7,32 @@ RCONFLICTS:${PN}="xcsoar"
 SRCREV:pn-xcsoar-testing = "${AUTOREV}" 
 
 SRC_URI = "git://github.com/XCSoar/XCSoar.git;protocol=git;branch=master \
+	file://ovmenu-x.service \
 "
 
+inherit systemd
+
 require xcsoar.inc
+
+PACKAGES += "ovmenu-x"
+RDEPENDS:ovmenu-x += " \
+	${PN} \
+	ovmenu-ng-skripts \
+	autofs-config \
+"
+RCONFLICTS:ovmenu-x += "ovmenu-ng-autostart"
+SYSTEMD_PACKAGES = "ovmenu-x"
+SYSTEMD_SERVICE:ovmenu-x = "ovmenu-x.service"
+
+do_compile:append() {
+	oe_runmake output/UNIX/bin/OpenVarioMenu
+}
+
+do_install:append() {
+	install -m755 ${S}/output/UNIX/bin/OpenVarioMenu ${D}${bindir}
+
+	install -d ${D}${systemd_unitdir}/system
+	install -m644 ${WORKDIR}/ovmenu-x.service ${D}${systemd_unitdir}/system
+}
+
+FILES:ovmenu-x += "${bindir}/OpenVarioMenu"

--- a/meta-ov/recipes-core/images/openvario-image-testing.bb
+++ b/meta-ov/recipes-core/images/openvario-image-testing.bb
@@ -10,7 +10,7 @@ IMAGE_INSTALL += "\
     xcsoar-maps-default \
     sensord-testing\
     variod-testing \
-    ovmenu-ng \
+    ovmenu-x \
 "
 
 export IMAGE_BASENAME = "openvario-image-testing"


### PR DESCRIPTION
This is a replacement for the ovmenu-ng shell script. It is similar to the KoboMenu program, also using XCSoar's GUI toolkit.
Being a quick hack, a lot of features are missing. This is just a tech demo, and maybe I can convince you that a C++ based solution built on top of XCSoar's class library delivers the best user experience.