### PR TITLE
psplash: update override syntax to yocto 3.4 standard

### DIFF
--- a/meta-ov/recipes-core/psplash/psplash_git.bbappend
+++ b/meta-ov/recipes-core/psplash/psplash_git.bbappend
@@ -5,9 +5,9 @@ SPLASH_IMAGES = "file://psplash-ovlinux-img.h;outsuffix=default"
 SRC_URI += "file://psplash-rotation \
             file://psplash-start.service"
 
-do_install_append() {
+do_install:append() {
   install -d ${D}/opt/bin
   install -m 0755 ${WORKDIR}/psplash-rotation ${D}/opt/bin/psplash-rotation
 }
 
-FILES_${PN} += "/opt"
+FILES:${PN} += "/opt"


### PR DESCRIPTION
The hornister update requires a newer syntax. (and we need a github action that verifies bitbake recipes at least.)