### PR TITLE
autofs-config: use the new BitBake ":" separator instead of "_"

### DIFF
--- a/meta-ov/recipes-support/autofs-config/autofs-config_0.2.bb
+++ b/meta-ov/recipes-support/autofs-config/autofs-config_0.2.bb
@@ -10,7 +10,7 @@ SRC_URI = "\
 	file://usb-usbstick.automount \
 "
 
-SYSTEMD_SERVICE_${PN} = "usb-usbstick.mount usb-usbstick.automount"
+SYSTEMD_SERVICE:${PN} = "usb-usbstick.mount usb-usbstick.automount"
 
 do_configure() {
     :


### PR DESCRIPTION
regression introduced in bababfc4931d6a07b4ec154bf783d1c6fbd681f3