### PR TITLE
xcsoar.inc: remove leftovers

### DIFF
--- a/meta-ov/recipes-apps/xcsoar/xcsoar.inc
+++ b/meta-ov/recipes-apps/xcsoar/xcsoar.inc
@@ -75,9 +75,6 @@ do_compile() {
 }
 
 do_install() {
-	install -d ${D}/opt/conf
-	install -d ${D}/opt/conf/default
-
 	oe_runmake install-bin install-mo DESTDIR=${D}
 }
 


### PR DESCRIPTION
Those directories are not needed anymore after 6d2e078c05bf6cafe6571ec1d638c814f3db7546 and should be removed to avoid build errors.