### PR TITLE
linux-mainline: disable CONFIG_LEGACY_PTYS

### DIFF
--- a/meta-ov/recipes-kernel/linux/linux-mainline/debloat.cfg
+++ b/meta-ov/recipes-kernel/linux/linux-mainline/debloat.cfg
@@ -10,6 +10,8 @@
 # CONFIG_PID_NS is not set
 # CONFIG_NET_NS is not set
 
+# CONFIG_LEGACY_PTYS is not set
+
 # Enable only gzip and zstd for initramfs compression
 # CONFIG_RD_BZIP2 is not set
 # CONFIG_RD_LZMA is not set


### PR DESCRIPTION
This saves more than one second of boot time.

Closes https://github.com/Openvario/meta-openvario/issues/263