### PR TITLE
Timeout usbstick automount after 2 seconds

### DIFF
--- a/meta-ov/recipes-support/autofs-config/files/usb-usbstick.mount
+++ b/meta-ov/recipes-support/autofs-config/files/usb-usbstick.mount
@@ -1,5 +1,6 @@
 [Unit]
 Description=Automatically mount connected USB drives
+JobTimeoutSec=2
 
 [Mount]
 What=/dev/sda1


### PR DESCRIPTION
When user tries to perform any operation that involves USB stick (e.g.
"Download IGC") and USB stick is not inserted, openvario appears to
"freeze" - becomes unresponsive, with no way to recover.

This is because it waits for /dev/sda1 device to appear in order to
mount it.  With the default 90s timeout the system appears to be stuck.

This lowers the timeout to 2 seconds to "unstuck" the system quickly
enough before user gets frustrated.