### PR TITLE
sensord, variod: enable the real-time CPU scheduler

### DIFF
--- a/meta-ov/recipes-apps/sensord/files/sensord.service
+++ b/meta-ov/recipes-apps/sensord/files/sensord.service
@@ -5,5 +5,10 @@ Description=Sensor Daemon for Openvario Sensorboard
 ExecStart=/opt/bin/sensord -f -c /opt/conf/sensord.conf
 Restart=on-abort
 
+# enable real-time scheduling because the MS5611 chip is very
+# sensitive to timing
+CPUSchedulingPolicy=fifo
+CPUSchedulingPriority=20
+
 [Install]
 WantedBy=multi-user.target

--- a/meta-ov/recipes-apps/variod/files/variod.service
+++ b/meta-ov/recipes-apps/variod/files/variod.service
@@ -8,5 +8,10 @@ After=pulseaudio.service
 ExecStart=/opt/bin/variod -f -c /opt/conf/variod.conf
 Restart=on-abort
 
+# enable real-time scheduling to ensure that variod meets all
+# deadlines to keep the audio buffer full
+CPUSchedulingPolicy=fifo
+CPUSchedulingPriority=10
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The MS5611 chip appears to be extremely sensitive to timing problems;
it needs to be read at a fixed interval, or else you get wrong
values.  Therefore, sensord needs to have real-time scheduling.

variod also needs real-time scheduling because it needs to meet
PulseAudio's deadline to refill the buffer.

This commit assigns sensord a higher priority, because having correct
sensor values is more important than having a consisten vario tone.