### PR TITLE
autofs-config: configure timeout on the device, not on the mount

### DIFF
--- a/meta-ov/recipes-support/autofs-config/autofs-config_0.2.bb
+++ b/meta-ov/recipes-support/autofs-config/autofs-config_0.2.bb
@@ -6,6 +6,7 @@ PR = "r1"
 inherit allarch systemd
 
 SRC_URI = "\
+	file://dev-sda1.device \
 	file://boot.mount \
 	file://boot.automount \
 	file://usb-usbstick.mount \
@@ -30,9 +31,14 @@ do_compile() {
 do_install() {
 	install -d ${D}${systemd_unitdir}/system
 	install -m 0644 \
+		${WORKDIR}/dev-sda1.device \
 		${WORKDIR}/boot.mount \
 		${WORKDIR}/boot.automount \
 		${WORKDIR}/usb-usbstick.mount \
 		${WORKDIR}/usb-usbstick.automount \
 		${D}${systemd_unitdir}/system
 }
+
+FILES:${PN} += " \
+	${systemd_unitdir}/system/dev-sda1.device \
+"

--- a/meta-ov/recipes-support/autofs-config/files/dev-sda1.device
+++ b/meta-ov/recipes-support/autofs-config/files/dev-sda1.device
@@ -1,0 +1,3 @@
+[Unit]
+Description=USB stick
+JobRunningTimeoutSec=2

--- a/meta-ov/recipes-support/autofs-config/files/usb-usbstick.mount
+++ b/meta-ov/recipes-support/autofs-config/files/usb-usbstick.mount
@@ -1,6 +1,5 @@
 [Unit]
 Description=Automatically mount connected USB drives
-JobTimeoutSec=2
 
 [Mount]
 What=/dev/sda1


### PR DESCRIPTION
This is the proper fix for
https://github.com/Openvario/meta-openvario/pull/270 because this is
the way systemd's fstab generator does it; it translates
"x-systemd.device-timeout" ("Configure how long systemd should wait
for a device to show up before giving up") to "JobRunningTimeoutSec"
in the device unit:
 https://github.com/systemd/systemd/blob/main/src/shared/generator.c#L281

The journal now looks like this:

 systemd[1]: usb-usbstick.automount: Got automount request for /usb/usbstick, triggered by 1224 (ls)
 systemd[1]: dev-sda1.device: Job dev-sda1.device/start timed out.
 systemd[1]: Timed out waiting for device USB stick.
 systemd[1]: Dependency failed for Automatically mount connected USB drives.
 systemd[1]: usb-usbstick.mount: Job usb-usbstick.mount/start failed with result 'dependency'.
 systemd[1]: dev-sda1.device: Job dev-sda1.device/start failed with result 'timeout'.

Before, it looked like this:

 systemd[1]: usb-usbstick.automount: Got automount request for /usb/usbstick, triggered by 1320 (ls)
 systemd[1]: usb-usbstick.mount: Job usb-usbstick.mount/start timed out.
 systemd[1]: Timed out mounting Automatically mount connected USB drives.
 systemd[1]: usb-usbstick.mount: Job usb-usbstick.mount/start failed with result 'timeout'.
 systemd[1]: Unnecessary job was removed for /dev/sda1.

Now systemd clearly states that waiting for the USB stick has timed
out, not that mounting it has timed out.