### PR TITLE
sensord, variod, xcsoar: switch GitHub URLs to "protocol=https"

### DIFF
--- a/meta-ov/recipes-apps/sensord/sensord-testing_git.bb
+++ b/meta-ov/recipes-apps/sensord/sensord-testing_git.bb
@@ -6,7 +6,7 @@ PR = "r10"
 inherit systemd
 SRCREV:pn-sensord-testing = "${AUTOREV}"
 
-SRC_URI = "git://github.com/Openvario/sensord.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/Openvario/sensord.git;protocol=https;branch=master \
 			file://sensord.cfgmgr \			  
 	file://sensord.socket \
 	file://sensord@.service \

--- a/meta-ov/recipes-apps/sensord/sensord_0.3.5.bb
+++ b/meta-ov/recipes-apps/sensord/sensord_0.3.5.bb
@@ -7,7 +7,7 @@ S = "${WORKDIR}/git"
 
 inherit systemd
 
-SRC_URI = "git://github.com/Openvario/sensord.git;protocol=git;tag=${PV} \
+SRC_URI = "git://github.com/Openvario/sensord.git;protocol=https;tag=${PV} \
 "
 
 require sensord.inc

--- a/meta-ov/recipes-apps/variod/variod-testing_git.bb
+++ b/meta-ov/recipes-apps/variod/variod-testing_git.bb
@@ -5,5 +5,5 @@ PR = "r12"
 
 SRCREV:pn-variod-testing = "${AUTOREV}" 
 
-SRC_URI:append = " git://github.com/Openvario/variod.git;protocol=git;branch=master "
+SRC_URI:append = " git://github.com/Openvario/variod.git;protocol=https;branch=master "
 

--- a/meta-ov/recipes-apps/variod/variod_0.3.1.bb
+++ b/meta-ov/recipes-apps/variod/variod_0.3.1.bb
@@ -2,5 +2,5 @@ require variod.inc
 
 PR = "r2"
 
-SRC_URI:append = " git://github.com/Openvario/variod.git;protocol=git;tag=${PV} "
+SRC_URI:append = " git://github.com/Openvario/variod.git;protocol=https;tag=${PV} "
 

--- a/meta-ov/recipes-apps/xcsoar/xcsoar-testing_git.bb
+++ b/meta-ov/recipes-apps/xcsoar/xcsoar-testing_git.bb
@@ -6,7 +6,7 @@ RCONFLICTS:${PN}="xcsoar"
 
 SRCREV:pn-xcsoar-testing = "${AUTOREV}" 
 
-SRC_URI = "git://github.com/XCSoar/XCSoar.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/XCSoar/XCSoar.git;protocol=https;branch=master \
 "
 
 require xcsoar.inc

--- a/meta-ov/recipes-apps/xcsoar/xcsoar_7.23.bb
+++ b/meta-ov/recipes-apps/xcsoar/xcsoar_7.23.bb
@@ -4,7 +4,7 @@
 PR="r0"
 RCONFLICTS:${PN}="xcsoar-testing"
 
-SRC_URI = "git://github.com/XCSoar/XCSoar.git;protocol=git;tag=v${PV} \
+SRC_URI = "git://github.com/XCSoar/XCSoar.git;protocol=https;tag=v${PV} \
 "
 
 require xcsoar.inc


### PR DESCRIPTION
GitHub has switched off plain git.