### PR TITLE
xcsoar, sensord, variod: add SRCREV

### DIFF
--- a/meta-ov/recipes-apps/sensord/sensord_0.3.5.bb
+++ b/meta-ov/recipes-apps/sensord/sensord_0.3.5.bb
@@ -7,7 +7,8 @@ S = "${WORKDIR}/git"
 
 inherit systemd
 
-SRC_URI = "git://github.com/Openvario/sensord.git;protocol=https;branch=master;tag=${PV} \
-"
+SRC_URI = "git://github.com/Openvario/sensord.git;protocol=https;branch=master"
+
+SRCREV = "465e3560583266aa9e1f161c7a3d43207f2b9e08"
 
 require sensord.inc

--- a/meta-ov/recipes-apps/variod/variod_0.3.1.bb
+++ b/meta-ov/recipes-apps/variod/variod_0.3.1.bb
@@ -2,5 +2,6 @@ require variod.inc
 
 PR = "r2"
 
-SRC_URI:append = " git://github.com/Openvario/variod.git;protocol=https;branch=master;tag=${PV} "
+SRC_URI:append = "git://github.com/Openvario/variod.git;protocol=https;branch=master"
 
+SRCREV = "aaa495919af67a6299b84fee0127ac64a1f6a8c3"

--- a/meta-ov/recipes-apps/xcsoar/xcsoar_7.23.bb
+++ b/meta-ov/recipes-apps/xcsoar/xcsoar_7.23.bb
@@ -4,7 +4,9 @@
 PR="r0"
 RCONFLICTS:${PN}="xcsoar-testing"
 
-SRC_URI = "git://github.com/XCSoar/XCSoar.git;protocol=https;branch=master;tag=v${PV} \
+SRC_URI = "git://github.com/XCSoar/XCSoar.git;protocol=https;branch=master \
 "
+
+SRCREV = "6c33d2697576c6e408ddb9f553430050f91efb73"
 
 require xcsoar.inc


### PR DESCRIPTION
Fixes BitBake error:

 FetchError("Recipe uses a floating tag/branch without a fixed SRCREV yet doesn't call bb.fetch2.get_srcrev() (use SRCPV in PV for OE).", None)

Closes https://github.com/Openvario/meta-openvario/issues/306