### PR TITLE
improve backup and restore procedure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@
 OpenVario*rootfs.img.gz
 .DS_Store
 bitbake.lock
+.project
 cache/
 downloads/
 sstate-cache/
 tmp/
 build/
+.settings/

--- a/meta-ov/recipes-apps/ovmenu-ng-skripts/files/system-info.sh
+++ b/meta-ov/recipes-apps/ovmenu-ng-skripts/files/system-info.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+#
+# system-info.sh
+# System info script gives an overview which packages and which versions are instaled
+#
+# Created by Blaubart,        2022-02-08
+#
+
+# collect info of system and more installed packages
+IMAGE_VERSION=$(cat /etc/os-release | grep VERSION_ID | cut -d '=' -f 2)
+KERNEL_VERSION=$(uname -r)
+XCSOAR_MAPS_VERSION=$(opkg list-installed xcsoar-maps* | cut -d '-' -f 4)
+XCSOAR_MENU=$(opkg list-installed xcsoar-menu* | cut -d '-' -f 3)
+IP_ETH0=$(ip route | grep eth0 | head -n 1 | cut -d ' ' -f 8)
+MAC=`ip li|grep -A 1 eth0|tail -n 1|cut -d ' ' -f 6`
+HOSTNAME=$(cat /etc/hostname)
+IP_WLAN=$(ip route | grep wlan0 | head -n 1| cut -d ' ' -f 8)
+I2C_TOOLS=$(opkg list-installed i2c-tools | cut -d '-' -f 3)
+E2FSPROGS=$(opkg list-installed e2fsprogs | cut -d '-' -f 2)
+USB_MODESWITCH=$(opkg list-installed usb-modeswitch | cut -d '-' -f 3)
+
+# collect status of SSH, variod and sensord
+if  /bin/systemctl --quiet is-enabled dropbear.socket
+then 
+	SSH_STATUS=enabled
+else 
+	SSH_STATUS=disabled
+fi
+
+if /bin/systemctl --quiet is-enabled variod
+then 
+	VARIOD_STATUS=enabled
+else 
+	VARIOD_STATUS=disabled
+fi
+	
+if /bin/systemctl --quiet is-enabled sensord
+then 
+	SENSORD_STATUS=enabled
+else 
+	SENSORD_STATUS=disabled
+fi
+		
+#print info of system and packages
+echo ' Image: '$IMAGE_VERSION
+echo ' Kernel: '$KERNEL_VERSION
+
+# collect info of installed packages, depending of testing or stable version is used
+if [ -n "$(opkg list-installed xcsoar-testing)" ]
+then
+	XCSOAR_VERSION=$(opkg list-installed xcsoar-testing | cut -d ' - ' -f 3)
+	echo ' XCSoar-testing: '$XCSOAR_VERSION
+else
+	XCSOAR_VERSION=$(opkg list-installed xcsoar         | cut -d '-'   -f 2)
+	echo ' XCSoar:'$XCSOAR_VERSION
+fi
+
+echo ' Maps:'$XCSOAR_MAPS_VERSION
+echo ' Menu:'$XCSOAR_MENU
+
+if [ -n "$(opkg list-installed sensord-testing)" ] 
+then
+	SENSORD_VERSION=$(opkg list-installed sensord-testing | cut -d ' - ' -f 3)
+	echo ' sensord-testing: '$SENSORD_VERSION
+else
+	SENSORD_VERSION=$(opkg list-installed sensord         | cut -d '-'   -f 2)
+	echo ' sensord:'$SENSORD_VERSION
+fi
+
+if [ -n "$(opkg list-installed variod-testing)" ] 
+then
+	VARIOD_VERSION=$(opkg list-installed variod-testing | cut -d ' - ' -f 3)
+	echo ' variod-testing: '$VARIOD_VERSION
+else
+	VARIOD_VERSION=$(opkg list-installed variod         | cut -d '-'   -f 2)
+	echo ' variod:'$VARIOD_VERSION
+fi
+
+echo ' IP eth0: '$IP_ETH0
+echo ' MAC-address eth0: '$MAC
+echo ' Hostname: '$HOSTNAME
+echo ' IP wlan0: '$IP_WLAN
+echo -e '\n'
+echo ' supplementary packages that are not included\n in every image:'
+echo ' i2c-tools:'$I2C_TOOLS
+echo ' e2fsprogs:'$E2FSPROGS
+echo ' usb-modeswitch:'$USB_MODESWITCH
+echo -e '\n'
+echo ' Status of SSH, variod and sensord:'
+echo ' SSH is '$SSH_STATUS
+echo ' variod is '$VARIOD_STATUS
+echo ' sensord is '$SENSORD_STATUS

--- a/meta-ov/recipes-apps/ovmenu-ng-skripts/files/transfer-xcsoar.sh
+++ b/meta-ov/recipes-apps/ovmenu-ng-skripts/files/transfer-xcsoar.sh
@@ -20,8 +20,8 @@
 # openvario/backup/<MAC address of eth0>/
 # So you can store backups from more than one OV on the same stick!
 
-echo ' [..........] Starting'
-echo ' [#.........] Wait until "DONE !!" appears before you exit!'
+echo ' [==========] Starting'
+echo ' [#=========] Wait until "DONE !!" appears before you exit!'
 
 # Provident background system buffer sync to help later syncs finish quicker
 sync&
@@ -49,7 +49,7 @@ restore() {
 		rsync --recursive --mkpath --checksum --quiet --progress "$1" "$2"
 		test ${RSYNC_EXIT:=$?} -eq 0
 	then
-		echo " [####......] All $3 files have been restored."
+		echo " [####======] All $3 files have been restored."
 	else 
 		>&2 echo " An rsync error $RSYNC_EXIT has occurred!"
 	fi
@@ -59,7 +59,7 @@ restore() {
 
 case `basename "$0"` in
 backup-system.sh)
-	echo ' [##........] System check ...'
+	echo ' [##========] System check ...'
 	
 	# Store SSH status 
 	if   /bin/systemctl --quiet is-enabled dropbear.socket
@@ -81,7 +81,7 @@ backup-system.sh)
 	# Copy brightness setting
 	cat /sys/class/backlight/lcd/brightness > /home/root/brightness
 
-	echo ' [####......] Starting backup ...'
+	echo ' [####======] Starting backup ...'
 	# Copy all directories and files from list below to backup directory recursively.
 	# We use --checksum here due to cubieboards not having an rtc clock
 	if 
@@ -100,18 +100,18 @@ backup-system.sh)
 			LISTE
 		test ${RSYNC_EXIT:=$?} -eq 0
 	then
-		echo ' [######....] All files and settings have been backed up.'
+		echo ' [######====] All files and settings have been backed up.'
 	else 
 		>&2 echo " An rsync error $RSYNC_EXIT has occurred!"
 	fi;;
 	
 restore-xcsoar.sh)
-	echo ' [##........] Starting restore of XCSoar ...'
+	echo ' [##========] Starting restore of XCSoar ...'
 	# Call Shell Function defined above
 	restore "$USB_PATH/$BACKUP/$MAC/$XCSOAR_PATH"/ "$XCSOAR_PATH"/ XCSoar;;
 	
 restore-system.sh)
-	echo ' [##........] Starting restore ...'
+	echo ' [##========] Starting restore ...'
 
 	# Eliminate /etc/opkg backup in case it's present
 	rm -rf "$USB_PATH/$BACKUP/$MAC"/etc/opkg/
@@ -123,14 +123,14 @@ restore-system.sh)
 	case `cat /home/root/ssh-status` in
 	enabled)
 		/bin/systemctl enable  --quiet --now dropbear.socket
-		echo " [####......] SSH has been enabled permanently.";;
+		echo " [####======] SSH has been enabled permanently.";;
 	temporary)
 		/bin/systemctl disable --quiet --now dropbear.socket
 		/bin/systemctl start   --quiet --now dropbear.socket
-		echo " [####......] SSH has been enabled temporarily.";;
+		echo " [####======] SSH has been enabled temporarily.";;
 	disabled)
 		/bin/systemctl disable --quiet --now dropbear.socket
-		echo " [####......] SSH has been disabled.";;
+		echo " [####======] SSH has been disabled.";;
 	esac
 	
 	# Restore variod and sensord status 
@@ -138,22 +138,22 @@ restore-system.sh)
 	do
 		case `cat /home/root/$DAEMON-status` in
 		enabled)  /bin/systemctl  enable --quiet --now $DAEMON
-		          echo " [#####.....] $DAEMON has been enabled.";;
+		          echo " [#####=====] $DAEMON has been enabled.";;
 		disabled) /bin/systemctl disable --quiet --now $DAEMON
-		          echo " [#####.....] $DAEMON has been disabled.";;
+		          echo " [#####=====] $DAEMON has been disabled.";;
 		esac
 	done
 
 	# Restore brightness setting
 	cat /home/root/brightness > /sys/class/backlight/lcd/brightness
-	echo " [######....] brightness setting has been restored.";;
+	echo " [######====] brightness setting has been restored.";;
 *)
 	>&2 echo 'call as backup-system.sh, restore-xcsoar.sh or restore-system.sh'
 	exit 1;;
 esac
 
 # Sync the system buffer to make sure all data is on disk
-echo ' [#######...] Please wait a moment, synchronization is not yet complete!'
+echo ' [#######===] Please wait a moment, synchronization is not yet complete!'
 sync
 echo ' [##########] DONE !! ---------------------------------------------------'
 exit $RSYNC_EXIT

--- a/meta-ov/recipes-apps/ovmenu-ng-skripts/files/transfer-xcsoar.sh
+++ b/meta-ov/recipes-apps/ovmenu-ng-skripts/files/transfer-xcsoar.sh
@@ -1,45 +1,159 @@
 #!/bin/sh
+#
+# transfer-xcsoar.sh
+# System backup transfer script to and from usbstick for Openvario and XCSoar
+#
+# Created by lordfolken         2022-02-08
+# Enhanced by 7lima & Blaubart  2022-06-19
+#
+# This backup and restore script stores all XCSoar settings and relevant
+# Openvario settings like:
+#
+# -brightness of the display
+# -rotation
+# -touch screen calibration
+# -language settings
+# -dropbear settings
+# -SSH, variod and sensord status
+# 
+# backups are stored at USB stick at:
+# openvario/backup/<MAC address of eth0>/
+# So you can store backups from more than one OV on the same stick!
 
-# Transfer script for Up/Downloadng data to usbstick
+echo ' [..........] Starting'
+echo ' [#.........] Wait until "DONE !!" appears before you exit!'
 
-USB_PATH="/usb/usbstick/openvario/"
-XCSOAR_PATH="/home/root/.xcsoar"
+# Provident background system buffer sync to help later syncs finish quicker
+sync&
 
-case "$(basename "$0")" in
-	'download-all.sh')
-		SRC_PATH="$XCSOAR_PATH"
-		DEST_PATH="$USB_PATH/download/xcsoar"
-		;;
-	'upload-xcsoar.sh')
-		SRC_PATH="$USB_PATH/upload/xcsoar"
-		DEST_PATH="$XCSOAR_PATH"
-		;;
-	'upload-all.sh')
-		SRC_PATH="$USB_PATH/upload"
-		DEST_PATH="$XCSOAR_PATH"
-		;;
-	*)
-		>&2 echo 'call as download-all.sh, upload-xcsoar.sh or upload-all.sh'
-		exit 1
+# Path where the USB stick is mounted
+USB_PATH=/usb/usbstick
+
+# XCSoar settings path
+XCSOAR_PATH=/home/root/.xcsoar
+
+# Backup path within the USB stick
+BACKUP=openvario/backup
+
+# MAC address of the Ethernet device eth0 to do a separate backup
+MAC=`ip li|grep -A 1 eth0|tail -n 1|cut -d ' ' -f 6|sed -e s/:/-/g`
+
+# Restore Shell Function: calls rsync with unified options. 
+# Copies all files and dirs from source recursively. Parameters:
+# $1 source
+# $2 target
+# $3 comment about type of items
+restore() {
+	if 
+		# We use --checksum here due to cubieboards not having an rtc clock
+		rsync --recursive --mkpath --checksum --quiet --progress "$1" "$2"
+		test ${RSYNC_EXIT:=$?} -eq 0
+	then
+		echo " [####......] All $3 files have been restored."
+	else 
+		>&2 echo " An rsync error $RSYNC_EXIT has occurred!"
+	fi
+	# Provident system buffer sync to help later syncs finish quicker
+	sync&
+}
+
+case `basename "$0"` in
+backup-system.sh)
+	echo ' [##........] System check ...'
+	
+	# Store SSH status 
+	if   /bin/systemctl --quiet is-enabled dropbear.socket
+	then	echo enabled
+	elif /bin/systemctl --quiet is-active  dropbear.socket
+	then	echo temporary
+	else	echo disabled  
+	fi > /home/root/ssh-status
+
+	# Store variod and sensord status
+	for DAEMON in variod sensord
+	do
+		if /bin/systemctl --quiet is-enabled $DAEMON
+		then echo  enabled
+		else echo disabled  
+		fi > /home/root/$DAEMON-status
+	done
+
+	# Copy brightness setting
+	cat /sys/class/backlight/lcd/brightness > /home/root/brightness
+
+	echo ' [####......] Starting backup ...'
+	# Copy all directories and files from list below to backup directory recursively.
+	# We use --checksum here due to cubieboards not having an rtc clock
+	if 
+		rsync --files-from - --archive --recursive --quiet \
+		      --relative --mkpath --checksum --safe-links \
+		      --progress \
+			/ "$USB_PATH/$BACKUP/$MAC"/ <<-LISTE
+				/etc/locale.conf
+				/etc/udev/rules.d/libinput-ts.rules
+				/etc/pointercal
+				/etc/dropbear
+				/home/root
+				/opt/conf
+				/var/lib/connman
+				/boot/config.uEnv
+			LISTE
+		test ${RSYNC_EXIT:=$?} -eq 0
+	then
+		echo ' [######....] All files and settings have been backed up.'
+	else 
+		>&2 echo " An rsync error $RSYNC_EXIT has occurred!"
+	fi;;
+	
+restore-xcsoar.sh)
+	echo ' [##........] Starting restore of XCSoar ...'
+	# Call Shell Function defined above
+	restore "$USB_PATH/$BACKUP/$MAC/$XCSOAR_PATH"/ "$XCSOAR_PATH"/ XCSoar;;
+	
+restore-system.sh)
+	echo ' [##........] Starting restore ...'
+
+	# Eliminate /etc/opkg backup in case it's present
+	rm -rf "$USB_PATH/$BACKUP/$MAC"/etc/opkg/
+
+	# Call Shell Function defined above
+	restore "$USB_PATH/$BACKUP/$MAC"/ / "Openvario and XCSoar"
+
+	# Restore SSH status 
+	case `cat /home/root/ssh-status` in
+	enabled)
+		/bin/systemctl enable  --quiet --now dropbear.socket
+		echo " [####......] SSH has been enabled permanently.";;
+	temporary)
+		/bin/systemctl disable --quiet --now dropbear.socket
+		/bin/systemctl start   --quiet --now dropbear.socket
+		echo " [####......] SSH has been enabled temporarily.";;
+	disabled)
+		/bin/systemctl disable --quiet --now dropbear.socket
+		echo " [####......] SSH has been disabled.";;
+	esac
+	
+	# Restore variod and sensord status 
+	for DAEMON in variod sensord
+	do
+		case `cat /home/root/$DAEMON-status` in
+		enabled)  /bin/systemctl  enable --quiet --now $DAEMON
+		          echo " [#####.....] $DAEMON has been enabled.";;
+		disabled) /bin/systemctl disable --quiet --now $DAEMON
+		          echo " [#####.....] $DAEMON has been disabled.";;
+		esac
+	done
+
+	# Restore brightness setting
+	cat /home/root/brightness > /sys/class/backlight/lcd/brightness
+	echo " [######....] brightness setting has been restored.";;
+*)
+	>&2 echo 'call as backup-system.sh, restore-xcsoar.sh or restore-system.sh'
+	exit 1;;
 esac
 
-if [ ! -d "$SRC_PATH" ] || [ ! -d "$DEST_PATH" ]; then
-	>&2 echo "Source $SRC_PATH or destination path $DEST_PATH does not exist"
-	exit 1
-fi
-
-if [ -z "$(find "$SRC_PATH" -type f | head -n 1 2>/dev/null)" ]; then
-	echo 'No files found !!!'
-else
-  # We use -c here due to cubieboards not having an rtc clock
-	if rsync -r -c --progress "${SRC_PATH}/" "$DEST_PATH/"; then
-		echo 'All files transfered successfully.'
-	else
-		>&2 echo 'An error has occured!'
-		exit 1
-	fi
-fi
-
-# Sync the buffer to be sure data is on disk
+# Sync the system buffer to make sure all data is on disk
+echo ' [#######...] Please wait a moment, synchronization is not yet complete!'
 sync
-echo 'Done !!'
+echo ' [##########] DONE !! ---------------------------------------------------'
+exit $RSYNC_EXIT

--- a/meta-ov/recipes-apps/ovmenu-ng-skripts/ovmenu-ng-skripts_0.1.bb
+++ b/meta-ov/recipes-apps/ovmenu-ng-skripts/ovmenu-ng-skripts_0.1.bb
@@ -44,9 +44,9 @@ do_install() {
 		${S}/ov-calibrate-ts.sh \
 		${D}${bindir}/
 	cd ${D}${bindir}
-	ln -s -r transfer-xcsoar.sh upload-all.sh
-	ln -s -r transfer-xcsoar.sh upload-xcsoar.sh
-	ln -s -r transfer-xcsoar.sh download-all.sh
+	ln -s -r transfer-xcsoar.sh restore-system.sh
+	ln -s -r transfer-xcsoar.sh restore-xcsoar.sh
+	ln -s -r transfer-xcsoar.sh backup-system.sh
 }
 
 FILES:${PN} = " \

--- a/meta-ov/recipes-apps/ovmenu-ng-skripts/ovmenu-ng-skripts_0.1.bb
+++ b/meta-ov/recipes-apps/ovmenu-ng-skripts/ovmenu-ng-skripts_0.1.bb
@@ -23,6 +23,7 @@ SRC_URI = "\
 	file://update-system.sh \
 	file://download-igc.sh \
 	file://transfer-xcsoar.sh \
+	file://system-info.sh \
 	file://ov-calibrate-ts.sh \
 "
 
@@ -41,12 +42,14 @@ do_install() {
 		${S}/update-system.sh \
 		${S}/download-igc.sh \
 		${S}/transfer-xcsoar.sh \
+		${S}/system-info.sh \
 		${S}/ov-calibrate-ts.sh \
 		${D}${bindir}/
 	cd ${D}${bindir}
 	ln -s -r transfer-xcsoar.sh restore-system.sh
 	ln -s -r transfer-xcsoar.sh restore-xcsoar.sh
 	ln -s -r transfer-xcsoar.sh backup-system.sh
+	ln -s -r transfer-xcsoar.sh upload-xcsoar.sh
 }
 
 FILES:${PN} = " \

--- a/meta-ov/recipes-apps/ovmenu-ng/files/ovmenu-ng.sh
+++ b/meta-ov/recipes-apps/ovmenu-ng/files/ovmenu-ng.sh
@@ -44,10 +44,12 @@ function submenu_file() {
 	--title "[ F I L E ]" \
 	--begin 3 4 \
 	--menu "You can use the UP/DOWN arrow keys" 15 50 4 \
-	Download_IGC   "Download IGC files to USB" \
-	Download  "Backup XCSoar and OV settings" \
-	Upload   "Restore XCSoar and OV settings" \
-	Upload_XCSoar   "Restore only XCSoar settings" \
+	Download_IGC   "Download XCSoar IGC files to USB" \
+	Update_Maps   "Update Maps" \
+	Upload_XCSoar   "Update or upload XCSoar files" \
+	Backup  "Backup XCSoar and OV settings" \
+	Restore   "Restore XCSoar and OV settings" \
+	Restore_XCSoar   "Restore only XCSoar settings" \
 	Back   "Back to Main" 2>"${INPUT}"
 
 	menuitem=$(<"${INPUT}")
@@ -55,9 +57,11 @@ function submenu_file() {
 	# make decsion
 	case $menuitem in
 		Download_IGC) download_igc_files;;
-		Download) download_files;;
-		Upload) upload_files;;
+		Update_Maps) update_maps_files;;
 		Upload_XCSoar) upload_xcsoar_files;;
+		Backup) backup_files;;
+		Restore) restore_files;;
+		Restore_XCSoar) restore_xcsoar_files;;
 		Exit) ;;
 esac
 }
@@ -69,7 +73,6 @@ function submenu_system() {
 	--begin 3 4 \
 	--menu "You can use the UP/DOWN arrow keys" 15 50 6 \
 	Update_System   "Update system software" \
-	Update_Maps   "Update Maps files" \
 	Calibrate_Sensors   "Calibrate Sensors" \
 	Calibrate_Touch   "Calibrate Touch" \
 	Settings   "System Settings" \
@@ -82,9 +85,6 @@ function submenu_system() {
 	case $menuitem in
 		Update_System)
 			update_system
-			;;
-		Update_Maps)
-			update_maps
 			;;
 		Calibrate_Sensors)
 			calibrate_sensors
@@ -337,19 +337,25 @@ function download_igc_files() {
 }
 
 # Copy XCSaor and OpenVario settings to /usb/usbstick/openvario/backup/<MAC address of eth0>
-function download_files() { 
+function backup_files() { 
 	/usr/bin/backup-system.sh >> /tmp/tail.$$ &
 	dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
 }
 
+# Copy usb/usbstick/openvario/upload/xcsoar to /home/root/.xcsoar
+function upload_xcsoar() { 
+	/usr/bin/upload-xcsoar.sh >> /tmp/tail.$$ &
+	dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
+}
+
 # Copy XCSaor and OpenVario settings from /usb/usbstick/openvario/backup/<MAC address of eth0>
-function upload_files(){
+function restore_files(){
 	/usr/bin/restore-system.sh >> /tmp/tail.$$ &
 	dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
 }
 
 # Copy /usb/usbstick/openvario/backup/<MAC address of eth0>/home/root/.xcsoar to /home/root/.xcsoar
-function upload_xcsoar_files(){
+function restore_xcsoar_files(){
 	/usr/bin/restore-xcsoar.sh >> /tmp/tail.$$ &
 	dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
 }

--- a/meta-ov/recipes-core/images/openvario-image-testing.bb
+++ b/meta-ov/recipes-core/images/openvario-image-testing.bb
@@ -8,7 +8,7 @@ IMAGE_INSTALL += "\
     xcsoar-menu \
     xcsoar-profiles \
     xcsoar-maps-default \
-    sensord-testing\
+    sensord-testing \
     variod-testing \
     ovmenu-ng \
 "


### PR DESCRIPTION
This backup script stores all XCSoar settings and relevant OpenVario settings like:

- brightness of the display
- rotation
- touch screen calibration
- language settings
- dropbear settings
- SSH, variod and sensord status

backups are stored at USB stick at:
- openvario/backup/"MAC address of eth0"/

So you can store more than one backup on the same stick!

We add system info script, too