### PR TITLE
Summary of the change

### DIFF
--- a/meta-ov/recipes-kernel/linux/files/0004-1.1V-fix-for-sun7i-a20.dtsi.patch
+++ b/meta-ov/recipes-kernel/linux/files/0004-1.1V-fix-for-sun7i-a20.dtsi.patch
@@ -1,0 +1,39 @@
+From 7e668bb8ed7ca437c2758de490162bfc33c67ab5 Mon Sep 17 00:00:00 2001
+From: Torsten Beyer <tb@pobox.com>
+Date: Tue, 19 Jul 2022 10:18:57 +0200
+Subject: [PATCH 4/4] 1.1V fix for sun7i-a20.dtsi
+
+Signed-off-by: Torsten Beyer <tb@pobox.com>
+---
+ arch/arm/boot/dts/sun7i-a20.dtsi | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm/boot/dts/sun7i-a20.dtsi b/arch/arm/boot/dts/sun7i-a20.dtsi
+index 5574299685ab..7cba57b5eab0 100644
+--- a/arch/arm/boot/dts/sun7i-a20.dtsi
++++ b/arch/arm/boot/dts/sun7i-a20.dtsi
+@@ -113,8 +113,8 @@
+ 				<864000	1300000>,
+ 				<720000	1200000>,
+ 				<528000	1100000>,
+-				<312000	1000000>,
+-				<144000	1000000>;
++				<312000	1100000>,
++				<144000	1100000>;
+ 			#cooling-cells = <2>;
+ 		};
+ 
+@@ -131,8 +131,8 @@
+ 				<864000	1300000>,
+ 				<720000	1200000>,
+ 				<528000	1100000>,
+-				<312000	1000000>,
+-				<144000	1000000>;
++				<312000	1100000>,
++				<144000	1100000>;
+ 			#cooling-cells = <2>;
+ 		};
+ 	};
+-- 
+2.15.0
+

--- a/meta-ov/recipes-kernel/linux/linux-openvario_5.17.5.bb
+++ b/meta-ov/recipes-kernel/linux/linux-openvario_5.17.5.bb
@@ -39,6 +39,7 @@ SRC_URI:append:sunxi = " \
 	file://0001-pwm-sun4i-convert-next_period-to-local-variable.patch \
 	file://0002-pwm-sun4i-calculate-delay_jiffies-directly-eliminate.patch \
 	file://0003-pwm-sun4i-calculate-the-delay-without-rounding-down-.patch \
+	file://Volumes/OpenVario/1.1V\ patch/0004-1.1V-fix-for-sun7i-a20.dtsi.patch\
 	\
 	file://openvario-common.dts \
 	file://openvario-43-rgb.dts \


### PR DESCRIPTION
This change, when applied, changes the OPP voltages for both 144MHz and 312MHz from 1V to 1.1V when creating Openvario images. This fixes freezes previously encountered.

Reason for this changes

Starting some time in 2021 Openvario users experienced inexplicable sudden crashes of their systems. I started analysing these issues by asking as many users as possible to document their hardware/software setup (see here https://docs.google.com/spreadsheets/d/1GQ6Q5XrnuuqNc-38CmHEat-4Oquq_l_X-1m1NVBfuBU/edit?usp=sharing) in order to find some sort of systematic behind these crashed (I failed :-). The results were inconclusive. Next I set up an OpenVarion test system with console output and tested various linux versions each with kernel debugging enabled. This lead to identification of the cpu_freq driver as being a possible culprit for these freezes. Many crashes happened as a consequence of cpu_freq changing CPU speed. A first workaround was tried fixing CPU speed at a defined frequency to stop cpu_freq from switching CPU speeds (for details of this work around see here https://github.com/tb59427/openvario-cpu-freq-fix). this work around significantly improved stability at the cost of a fixed cpu speed and potentially high power usage.

Further analysis revealed that the kernel tried to access parts of a struct with invalid addresses while access to the very same struct succeeded a few instructions earlier. With many insights from Samuel Holland of the linux-sunxi mailing list, we concluded that it wasn't the frequency but most likely OPP voltage settings of the CPU that created hardware instability resulting destroyed or wrong addresses. See thread here: https://groups.google.com/g/linux-sunxi/c/iAcd0PxOuOs .

Per the A20 SDK (https://linux-sunxi.org/A20) (see section DVFS) the DVFS OPP voltages for 144000 should be 1050000mV and for 312000 it should be 1100000mV. These voltages, however, are set to be 1000000mV for each of the affected frequencies in the upstream linux kernel sources. These low voltages obviously lead to hardware instabilities observed.

There was a commit for the linux source tree already in 2015 (a15b80f) which changed OPP voltages according to the A20 SDK documentation - however only specifically for the bananapi variant of the A20 board (arch/arm/boot/dts/sun7i-a20-bananapi.dts). For some unknown reason this patch never made it to the core sun7i-a20.dtsi file which is imported by all sun7i A20 dts files (but can be overwritten by dts files specifically designed for an A20 board make.

The suggestion on the linux-sunxi mailinglist was to increase OPP voltage by 100mV (thus pushing the OPP voltage for the lowest frequency even 50mV higher than the A20 SDK recommendation).

Weighing A20 SDK information against Samuel's sentiment (who has dealt with many A20 boards) I decided to go for the 110000mV for the lowest two frequencies. As the A20 SoC has two cpus OPP voltages have been increased for both frequencies.

What this change does

This change changes OPP voltages from 1V to 1.1V for the lowermost two CPU frequencies both for CPU0 and CPU1. These OPP voltages are set in arch/arm/boot/dts/sun7i-a20.dtsi of the linux source tree. This file gets imported by all other A20 dts files for specific variants of the A20 SoC. The OpenVario kernel recipes also include this file (via a chain of inclusions starting with "meta-openvario/meta-ov/recipes-krenel/linux/files/openvario-common.dts"). The change is applied during bitbake of the kernel by applying the patchfile to arch/arm/boot/dts/sun7i-a20.dtsi prior to compilation. Additionally the kernel bitbake file (meta-openvario/meta-ov/recipes-kernel/linux/linux-openvario_5.17.5.bb gets changed to apply the patchfile.

Other considerations

In theory I could have also changed the openvario-common.dts file for the OpenVario build in meta-ov/recipes-kernel/linux/files and overwritten the definitions imported from arch/arm/boot/dts/sun7i-a20.dtsi of the linux source tree. This would have avoided patching a kernel file during the bitbake process. On the other hand we would have buried a kernel dependency by copying a fraction of the kernel code into the OpenVario build. Should the kernel substantially change in the future - in particular arch/arm/boot/dts/sun7i-a20.dtsi we may run the risk over not noticing and running into inexplicable errors. Isolating this patch into a patch to a kernel file indicates that there is a dependency and with every new kernel building the basis for OpenVario we are now forced to review arch/arm/boot/dts/sun7i-a20.dtsi and whether the patch is still correct. I preferred this approach over "overwrite" in
openvario-common.dts.

Beware

This change needs revisiting everytime the kernel version for Openvario get's changed as new / different kernel versions may contain a different dtsi file for the A20.

It remains to be seen how well this change eliminates crashes. My test system runs rock stable with this change, other users on the xcsoar forum report this, too. But there are also hints that 1.1V may not be enough. It could well be that further increase (by 100mV) of the OPP voltages may be needed. Using the xcsoar forum to collect feedback will hopefully provide more clarity about this question.