### PR TITLE
Change of CPU OPP voltages to eliminate freezes

### DIFF
--- a/meta-ov/conf/machine/openvario-43-rgb.conf
+++ b/meta-ov/conf/machine/openvario-43-rgb.conf
@@ -4,6 +4,6 @@
 
 require ov-cubieboard2.inc
 
-KERNEL_DEVICETREE_SOURCE = "openvario-43-rgb.dts"
+KERNEL_DEVICETREE = "openvario-43-rgb.dtb"
 
 SHORT_OV_MACHINE= "AM43"

--- a/meta-ov/conf/machine/openvario-57-lvds-DS2.conf
+++ b/meta-ov/conf/machine/openvario-57-lvds-DS2.conf
@@ -4,6 +4,6 @@
 
 require ov-cubieboard2.inc
 
-KERNEL_DEVICETREE_SOURCE = "openvario-57-lvds-DS2.dts"
+KERNEL_DEVICETREE = "openvario-57-lvds-DS2.dtb"
 
 SHORT_OV_MACHINE= "CH57_2"

--- a/meta-ov/conf/machine/openvario-57-lvds.conf
+++ b/meta-ov/conf/machine/openvario-57-lvds.conf
@@ -4,6 +4,6 @@
 
 require ov-cubieboard2.inc
 
-KERNEL_DEVICETREE_SOURCE = "openvario-57-lvds.dts"
+KERNEL_DEVICETREE = "openvario-57-lvds.dtb"
 
 SHORT_OV_MACHINE= "CH57"

--- a/meta-ov/conf/machine/openvario-7-AM070-DS2.conf
+++ b/meta-ov/conf/machine/openvario-7-AM070-DS2.conf
@@ -4,6 +4,6 @@
 
 require ov-cubieboard2.inc
 
-KERNEL_DEVICETREE_SOURCE = "openvario-7-AM070-DS2.dts"
+KERNEL_DEVICETREE = "openvario-7-AM070-DS2.dtb"
 
 SHORT_OV_MACHINE= "AM70_2"

--- a/meta-ov/conf/machine/openvario-7-CH070-DS2.conf
+++ b/meta-ov/conf/machine/openvario-7-CH070-DS2.conf
@@ -4,6 +4,6 @@
 
 require ov-cubieboard2.inc
 
-KERNEL_DEVICETREE_SOURCE = "openvario-7-CH070-DS2.dts"
+KERNEL_DEVICETREE = "openvario-7-CH070-DS2.dtb"
 
 SHORT_OV_MACHINE= "CH70_2"

--- a/meta-ov/conf/machine/openvario-7-CH070.conf
+++ b/meta-ov/conf/machine/openvario-7-CH070.conf
@@ -4,6 +4,6 @@
 
 require ov-cubieboard2.inc
 
-KERNEL_DEVICETREE_SOURCE = "openvario-7-CH070.dts"
+KERNEL_DEVICETREE = "openvario-7-CH070.dtb"
 
 SHORT_OV_MACHINE= "CH70"

--- a/meta-ov/conf/machine/openvario-7-PQ070.conf
+++ b/meta-ov/conf/machine/openvario-7-PQ070.conf
@@ -4,6 +4,6 @@
 
 require ov-cubieboard2.inc
 
-KERNEL_DEVICETREE_SOURCE = "openvario-7-PQ070.dts"
+KERNEL_DEVICETREE = "openvario-7-PQ070.dtb"
 
 SHORT_OV_MACHINE= "PQ70"

--- a/meta-ov/conf/machine/ov-cubieboard2.inc
+++ b/meta-ov/conf/machine/ov-cubieboard2.inc
@@ -11,5 +11,3 @@ MACHINE_FEATURES:remove = "apm"
 
 IMAGE_CLASSES += "sdcard_image-openvario"
 IMAGE_FSTYPES = "openvario-sdimg"
-
-KERNEL_DEVICETREE = "openvario.dtb"

--- a/meta-ov/recipes-bsp/u-boot/files/bootenv.ini
+++ b/meta-ov/recipes-bsp/u-boot/files/bootenv.ini
@@ -18,12 +18,6 @@ done;
 [bootcmd_mmc0]
 echo Try to boot from mmc ...;
 run set_bootargs;
-
-# hard-coded DeviceTree file name because u-boot uses the standard
-# Cubieboard 2 DeviceTree, but the Linux kernel needs a custom
-# DeviceTree
-setenv fdtfile openvario.dtb;
-
 load mmc 0:1 ${fdt_addr_r} ${fdtfile};
 load mmc 0:1 ${kernel_addr_r} uImage;
 bootm ${kernel_addr_r} - ${fdt_addr_r}

--- a/meta-ov/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-ov/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -75,6 +75,7 @@ do_install:append:cubieboard2() {
 	install -m 644 -D ${WORKDIR}/ov_*.bmp ${D}/boot
 	install -m 644 -D ${WORKDIR}/config.uEnv ${D}/boot
 	cat ${WORKDIR}/font.env >>${D}/boot/config.uEnv
+	echo fdtfile=${KERNEL_DEVICETREE} >>${D}/boot/config.uEnv
 }
 
 do_deploy:append:cubieboard2() {
@@ -82,5 +83,5 @@ do_deploy:append:cubieboard2() {
 	install -m 644 -D ${WORKDIR}/ov_*.bmp ${DEPLOYDIR}/pics
 	install -m 644 -D ${WORKDIR}/config.uEnv ${DEPLOYDIR}
 	cat ${WORKDIR}/font.env >>${DEPLOYDIR}/config.uEnv
+	echo fdtfile=${KERNEL_DEVICETREE} >>${DEPLOYDIR}/config.uEnv
 }
-

--- a/meta-ov/recipes-core/images/openvario-base-image.bb
+++ b/meta-ov/recipes-core/images/openvario-base-image.bb
@@ -88,10 +88,10 @@ mask_systemd_units() {
 ROOTFS_POSTPROCESS_COMMAND += "mask_systemd_units;"
 
 delete_uimage() {
-	# delete the redundant uImage from the root partition; another
+	# delete the redundant kernel image from the root partition; another
 	# copy is on the /boot partition, and that one is used by
 	# u-boot
-	rm -f ${IMAGE_ROOTFS}/boot/uImage*
+	rm -f ${IMAGE_ROOTFS}/boot/*Image*
 }
 
 ROOTFS_POSTINSTALL_COMMAND += "delete_uimage;"

--- a/meta-ov/recipes-kernel/linux/linux-openvario_5.17.5.bb
+++ b/meta-ov/recipes-kernel/linux/linux-openvario_5.17.5.bb
@@ -5,9 +5,6 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 inherit kernel kernel-yocto siteinfo
 
-# Pull in the devicetree files into the rootfs
-RDEPENDS_${KERNEL_PACKAGE_NAME}-base += "kernel-devicetree"
-
 S = "${WORKDIR}/git"
 
 KBRANCH = "linux-5.17.y"

--- a/meta-ov/recipes-kernel/linux/linux-openvario_5.17.5.bb
+++ b/meta-ov/recipes-kernel/linux/linux-openvario_5.17.5.bb
@@ -66,10 +66,7 @@ KMACHINE ?= "${MACHINE}"
 KMETA = ".kernel-meta"
 
 do_configure:prepend:sunxi() {
-	if test -n "${KERNEL_DEVICETREE_SOURCE}"; then
-		cp ${WORKDIR}/openvario-common.dts ${S}/arch/arm/boot/dts/openvario-common.dts
-		cp ${WORKDIR}/${KERNEL_DEVICETREE_SOURCE} ${S}/arch/arm/boot/dts/openvario.dts
-	fi
+	cp ${WORKDIR}/openvario-*.dts ${S}/arch/arm/boot/dts/
 }
 
 FILES_${KERNEL_PACKAGE_NAME}-base:append = " ${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo"


### PR DESCRIPTION
This change, when applied, changes the OPP voltages for both 144MHz and 312MHz from 1V to 1.1V when creating Openvario images. This fixes freezes previously encountered.

Reason for this change

Starting some time in 2021 Openvario users experienced inexplicable sudden crashes of their systems. I started analysing these issues by asking as many users as possible to document their hardware/software setup (see here https://docs.google.com/spreadsheets/d/1GQ6Q5XrnuuqNc-38CmHEat-4Oquq_l_X-1m1NVBfuBU/edit?usp=sharing) in order to find some sort of systematic behind these crashed (I failed :-). The results were inconclusive. Next I set up an OpenVarion test system with console output and tested various linux versions each with kernel debugging enabled. This lead to identification of the cpu_freq driver as being a possible culprit for these freezes. Many crashes happened as a consequence of cpu_freq changing CPU speed. A first workaround was tried fixing CPU speed at a defined frequency to stop cpu_freq from switching CPU speeds (for details of this work around see here https://github.com/tb59427/openvario-cpu-freq-fix). this work around significantly improved stability at the cost of a fixed cpu speed and potentially high power usage.

Further analysis revealed that the kernel tried to access parts of a struct with invalid addresses while access to the very same struct succeeded a few instructions earlier. With many insights from Samuel Holland of the linux-sunxi mailing list, we concluded that it wasn't the frequency but most likely OPP voltage settings of the CPU that created hardware instability resulting destroyed or wrong addresses. See thread here: https://groups.google.com/g/linux-sunxi/c/iAcd0PxOuOs .

Per the A20 SDK (https://linux-sunxi.org/A20) (see section DVFS) the DVFS OPP voltages for 144000 should be 1050000mV and for 312000 it should be 1100000mV. These voltages, however, are set to be 1000000mV for each of the affected frequencies in the upstream linux kernel sources. These low voltages obviously lead to hardware instabilities observed.

There was a commit for the linux source tree already in 2015 (a15b80f) which changed OPP voltages according to the A20 SDK documentation - however only specifically for the bananapi variant of the A20 board (arch/arm/boot/dts/sun7i-a20-bananapi.dts). For some unknown reason this patch never made it to the core sun7i-a20.dtsi file which is imported by all sun7i A20 dts files (but can be overwritten by dts files specifically designed for an A20 board make.

The suggestion on the linux-sunxi mailinglist was to increase OPP voltage by 100mV (thus pushing the OPP voltage for the lowest frequency even 50mV higher than the A20 SDK recommendation).

Weighing A20 SDK information against Samuel's sentiment (who has dealt with many A20 boards) I decided to go for the 110000mV for the lowest two frequencies. As the A20 SoC has two cpus OPP voltages have been increased for both frequencies.

What this change does

This change changes OPP voltages from 1V to 1.1V for the lowermost two CPU frequencies both for CPU0 and CPU1. These OPP voltages are set in arch/arm/boot/dts/sun7i-a20.dtsi of the linux source tree. This file gets imported by all other A20 dts files for specific variants of the A20 SoC. The OpenVario kernel recipes also include this file (via a chain of inclusions starting with "meta-openvario/meta-ov/recipes-krenel/linux/files/openvario-common.dts"). The change is applied during bitbake of the kernel by applying the patchfile to arch/arm/boot/dts/sun7i-a20.dtsi prior to compilation. Additionally the kernel bitbake file (meta-openvario/meta-ov/recipes-kernel/linux/linux-openvario_5.17.5.bb gets changed to apply the patchfile.

Other considerations

In theory I could have also changed the openvario-common.dts file for the OpenVario build in meta-ov/recipes-kernel/linux/files and overwritten the definitions imported from arch/arm/boot/dts/sun7i-a20.dtsi of the linux source tree. This would have avoided patching a kernel file during the bitbake process. On the other hand we would have buried a kernel dependency by copying a fraction of the kernel code into the OpenVario build. Should the kernel substantially change in the future - in particular arch/arm/boot/dts/sun7i-a20.dtsi we may run the risk over not noticing and running into inexplicable errors. Isolating this patch into a patch to a kernel file indicates that there is a dependency and with every new kernel building the basis for OpenVario we are now forced to review arch/arm/boot/dts/sun7i-a20.dtsi and whether the patch is still correct. I preferred this approach over "overwrite" in
openvario-common.dts.

Beware

This change needs revisiting everytime the kernel version for Openvario get's changed as new / different kernel versions may contain a different dtsi file for the A20.

It remains to be seen how well this change eliminates crashes. My test system runs rock stable with this change, other users on the xcsoar forum report this, too. But there are also hints that 1.1V may not be enough. It could well be that further increase (by 100mV) of the OPP voltages may be needed. Using the xcsoar forum to collect feedback will hopefully provide more clarity about this question.