### PR TITLE
remove double quote at rotation value

### DIFF
--- a/meta-ov/recipes-core/psplash/files/psplash-rotation
+++ b/meta-ov/recipes-core/psplash/files/psplash-rotation
@@ -7,7 +7,7 @@ case "$(sed -n 's/^rotation=//p' /boot/config.uEnv | tr -d '"')" in
 		rotation=90
 		;;
 	"2")
-		rotation=18
+		rotation=180
 		;;
 	"1")
 		rotation=270

--- a/meta-ov/recipes-core/psplash/files/psplash-rotation
+++ b/meta-ov/recipes-core/psplash/files/psplash-rotation
@@ -2,12 +2,12 @@
 
 # convert fbcon/rotate to degrees
 
-case "$(sed -n 's/^rotation=//p' /boot/config.uEnv)" in
+case "$(sed -n 's/^rotation=//p' /boot/config.uEnv | tr -d '"')" in
 	"3")
 		rotation=90
 		;;
 	"2")
-		rotation=180
+		rotation=18
 		;;
 	"1")
 		rotation=270


### PR DESCRIPTION
If values are written ​​to the config file with C++ using the Write(const char *key, const char *value) function, they are entered as in the following example: rotation="0". In order for psplash-rotation to process these entries correctly, the quotation marks must be removed.