### PR TITLE
new daemon to store runtime values at config when shutdown the system

### DIFF
--- a/meta-ov/recipes-apps/ovmenu-ng/files/ovmenu-ng.sh
+++ b/meta-ov/recipes-apps/ovmenu-ng/files/ovmenu-ng.sh
@@ -266,10 +266,8 @@ function submenu_rotation() {
 
 		 menuitem=$(<"${INPUT}")
 
-		# update config
 		# uboot rotation
-		sed -i 's/^rotation=.*/rotation='$menuitem'/' /boot/config.uEnv
-		echo "$menuitem" >/sys/class/graphics/fbcon/rotate_all
+		echo "$menuitem" >/sys/class/graphics/fbcon/rotate
 		dialog --msgbox "New Setting saved !!\n Touch recalibration required !!" 10 50
 	else
 		dialog --backtitle "OpenVario" \

--- a/meta-ov/recipes-apps/store-runtime-value/files/store-runtime-value.service
+++ b/meta-ov/recipes-apps/store-runtime-value/files/store-runtime-value.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Store runtime values at Config
+ConditionPathExists=/opt/bin/store-runtime-value.sh
+After=basic.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/bin/true
+ExecStop=/bin/sh -c '/opt/bin/store-runtime-value.sh stop'
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-ov/recipes-apps/store-runtime-value/files/store-runtime-value.sh
+++ b/meta-ov/recipes-apps/store-runtime-value/files/store-runtime-value.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# chkconfig: 2345 20 80
+# description: Description comes here....
+
+case "$1" in 
+    start)
+       # code to start app comes here 
+       # example: daemon program_name &
+       ;;
+    stop)
+	   RotationValue=$(cat /sys/class/graphics/fbcon/rotate)
+	   sed -i "s/rotation=.*/rotation=$RotationValue/" /boot/config.uEnv
+       ;;
+    restart)
+       # code to stop and start app comes here 
+       # example: daemon program_name &
+       ;;
+    status)
+       # code to check status of app comes here 
+       # example: status program_name
+       ;;
+    *)
+       echo "Usage: $0 {start|stop|status|restart}"
+esac
+
+exit 0 

--- a/meta-ov/recipes-apps/store-runtime-value/store-runtime-value_0.1.bb
+++ b/meta-ov/recipes-apps/store-runtime-value/store-runtime-value_0.1.bb
@@ -1,0 +1,39 @@
+# store-runtime-value.service
+#
+# This script installes a daemon that persistently stores runtime variables in config.uEnv 
+# when the system is shut down, so that they can be read again after restart.
+#
+# Created by Blaubart         2023-03-30
+
+SUMMARY = "Store runtime value"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/${LICENSE};md5=c79ff39f19dfec6d293b95dea7b07891"
+
+PR = "r1"
+
+inherit allarch systemd
+
+RDEPENDS:${PN} = " \  
+		bash \
+"
+
+SRC_URI = "              \
+   file://store-runtime-value.service     \
+   file://store-runtime-value.sh     \
+   "
+   
+do_install() {
+    install -d ${D}/${systemd_unitdir}/system
+    install -d ${D}/opt/bin
+
+    install -m 0644 ${WORKDIR}/store-runtime-value.service      ${D}/${systemd_unitdir}/system
+    install -m 0755 ${WORKDIR}/store-runtime-value.sh           ${D}/opt/bin
+}
+
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE:${PN} = "store-runtime-value.service"
+
+FILES:${PN} += " \
+        ${systemd_unitdir}/system/store-runtime-value.service \
+    	/opt/bin/store-runtime-value.sh \
+"

--- a/meta-ov/recipes-core/images/openvario-base-image.bb
+++ b/meta-ov/recipes-core/images/openvario-base-image.bb
@@ -36,6 +36,7 @@ IMAGE_INSTALL = " \
     packagegroup-base \
     distro-feed-configs \
     nano \
+    store-runtime-value \
     openssh-sftp-server \
     tslib \
     tslib-tests \


### PR DESCRIPTION
This PR introduces a daemon that persists runtime variables during regular system shutdown. At the moment this daemon enables the rotation value to be saved in the /boot/config.uEnv in a reasonable manner, particularly with the X-menu. The daemon can easily be extended for more runtimer variables.

The daemon checks the current rotation setting in /sys/class/graphics/fbcon/rotate and store it in /boot/config.uEnv.

The PR also includes a change in ovmenu-ng.sh. Saving the display rotation in /boot/conf.uEnv has been removed here because this is now done by the daemon, primarily in preparation for the x-menu. Also the the display rotation is no longer saved in the /sys/class/graphics/fbcon/rotate_all, but in the /sys/class/graphics/fbcon/rotate. The reason for this is that the current rotation value can be read from the /sys/class/graphics/fbcon/rotate but not from /sys/class/graphics/fbcon/rotate_all.

So the daemon can be used with both the x-menu and the ng-menu. Its introduction later makes it easy to switch from the ng-menu to the x-menu.