### PR TITLE
Update "update-maps.sh"

### DIFF
--- a/meta-ov/recipes-apps/ovmenu-ng-skripts/files/update-maps.sh
+++ b/meta-ov/recipes-apps/ovmenu-ng-skripts/files/update-maps.sh
@@ -3,7 +3,7 @@ XCSOAR_MAP_PATH="/home/root/.xcsoar"
 MAP_PATH="/usb/usbstick/openvario/maps"
 
 if [ -z "$(ls $MAP_PATH/xcsoar-maps*.ipk 2>/dev/null)" ]; then
-        echo "No files for update found !!!"
+        echo "No *.ipk files for update found !!!"
 else
         for mapfile in $(find $MAP_PATH -name 'xcsoar-maps*.ipk'); do
                 echo $mapfile
@@ -12,7 +12,7 @@ else
 fi
 
 if [ -z "$(ls $MAP_PATH/*.xcm 2>/dev/null)" ]; then
-        echo "No files for update found !!!"
+        echo "No *.xcm files for update found !!!"
 else
         for mapfile in $(find $MAP_PATH -name '*.xcm'); do
                 echo $mapfile


### PR DESCRIPTION
If no ipk files and no xcm files are found, the script only returns two times the message to the user that no files for update were found. The message now states which file type was not found!