### PR TITLE
Revert "relax CPU clock and voltage constraints to provide higher per…

### DIFF
--- a/meta-ov/recipes-kernel/linux/files/0004-Set-minimum-CPU-voltage-to-1.2V.patch
+++ b/meta-ov/recipes-kernel/linux/files/0004-Set-minimum-CPU-voltage-to-1.2V.patch
@@ -1,10 +1,10 @@
 From 7d460400702a323c3dc796f95ce5e155767c0aca Mon Sep 17 00:00:00 2001
 From: Torsten Beyer <tb@pobox.com>
 Date: Sun, 28 Aug 2022 20:04:45 +0200
-Subject: [PATCH] Set minimum CPU voltage to 1.3V
+Subject: [PATCH] Set minimum CPU voltage to 1.2V
 
 The cubieboard2 dev spec says minimum voltage for lower frequencies should be 1.0iV and 1.1V respectively. Usage of cubieboards in OpenVarion
-show instable behaviour with voltages of 1.0V and 1.1V. Hence this change increases CPU voltage to 1.3V for the lowest CPU speeds.
+show instable behaviour with voltages of 1.0V and 1.1V. Hence this change increases CPU voltage to 1.2V for the lowest CPU speeds.
 ---
  arch/arm/boot/dts/sun7i-a20.dtsi | 12 ++++++------
  1 file changed, 6 insertions(+), 6 deletions(-)
@@ -16,28 +16,26 @@ index 5574299685ab..6902621d806f 100644
 @@ -112,9 +112,9 @@
  				<912000	1400000>,
  				<864000	1300000>,
--				<720000	1200000>,
+ 				<720000	1200000>,
 -				<528000	1100000>,
 -				<312000	1000000>,
 -				<144000	1000000>;
-+				<720000	1300000>,
-+				<528000	1300000>,
-+				<312000	1300000>,
-+				<144000	1300000>;
++				<528000	1200000>,
++				<312000	1200000>,
++				<144000	1200000>;
  			#cooling-cells = <2>;
  		};
  
 @@ -130,9 +130,9 @@
  				<912000	1400000>,
  				<864000	1300000>,
--				<720000	1200000>,
+ 				<720000	1200000>,
 -				<528000	1100000>,
 -				<312000	1000000>,
 -				<144000	1000000>;
-+				<720000	1300000>,
-+				<528000	1300000>,
-+				<312000	1300000>,
-+				<144000	1300000>;
++				<528000	1200000>,
++				<312000	1200000>,
++				<144000	1200000>;
  			#cooling-cells = <2>;
  		};
  	};

--- a/meta-ov/recipes-kernel/linux/linux-openvario_6.6.8.bb
+++ b/meta-ov/recipes-kernel/linux/linux-openvario_6.6.8.bb
@@ -36,7 +36,7 @@ SRC_URI = " \
 "
 
 SRC_URI:append:sunxi = " \
-	file://0004-Set-minimum-CPU-voltage-to-1.3V.patch\
+	file://0004-Set-minimum-CPU-voltage-to-1.2V.patch\
 	\
 	file://openvario-common.dts \
 	file://openvario-43-rgb.dts \

--- a/meta-ov/recipes-support/fix-cpu-freq/files/fix_cpu_freq.sh
+++ b/meta-ov/recipes-support/fix-cpu-freq/files/fix_cpu_freq.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 #
-# This script limits CPU frequency.
-# Together with the changes to sun7i-a20.dtsi it prevents voltage changes in
-# available frequency range. Beware: it must be a supported frequency
+# This script fixes CPU frequency thus effectively stopping the kernel from changing cpu frequency
+# You can change the frequency if you wish. To do so just change the value of CPU_FIX_FREQ to a different
+# number. Beware: it must be a supported frequency
 #
 
-CPU_FIX_FREQ=864000
+CPU_FIX_FREQ=720000
 
+echo $CPU_FIX_FREQ > /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
 echo $CPU_FIX_FREQ > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+echo $CPU_FIX_FREQ > /sys/devices/system/cpu/cpu1/cpufreq/scaling_min_freq
 echo $CPU_FIX_FREQ > /sys/devices/system/cpu/cpu1/cpufreq/scaling_max_freq


### PR DESCRIPTION
…formance, lower power and still prevent system freeze"

This reverts commit c01a30cdd28c617d7aff10bb7388ad3ce64dbe45.

Based on discussion in https://github.com/Openvario/meta-openvario/issues/372