### PR TITLE
replace defaulted equality operator to support pre g++-12 compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,17 @@ This will fetch the manifest file for the warrior branch.
 
 ### Starting the containerd build environment
 
+The "old" Ubuntu 18.04 build container (for warrior branch):
+
 ```
 sudo docker run -it --rm -v $(pwd):/workdir linuxianer99/ovbuild --workdir=/workdir
+cd poky
+```
+
+The "new" Debian 11 build container (for hardknott branch):
+
+```
+sudo docker run -it --rm -v $(pwd):/workdir ghcr.io/openvario/ovbuild-container:main --workdir=/workdir
 cd poky
 ```
 

--- a/recipes-apps/xcsoar/files/0002-replace-defaulted-equality-comparison.patch
+++ b/recipes-apps/xcsoar/files/0002-replace-defaulted-equality-comparison.patch
@@ -1,0 +1,38 @@
+From 2d1994d5ecf1b7d7fdfee403631c8f2a65b7d87d Mon Sep 17 00:00:00 2001
+From: bomilkar <ronald_niederhagen@freenet.de>
+Date: Thu, 6 Jun 2024 13:57:15 +0200
+Subject: [PATCH 2/3] replace defaulted equality comparison
+
+---
+ src/Geo/Flat/FlatGeoPoint.hpp | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/Geo/Flat/FlatGeoPoint.hpp b/src/Geo/Flat/FlatGeoPoint.hpp
+index db30016756..5f69b8dc24 100644
+--- a/src/Geo/Flat/FlatGeoPoint.hpp
++++ b/src/Geo/Flat/FlatGeoPoint.hpp
+@@ -69,7 +69,9 @@ struct FlatGeoPoint : IntPoint2D {
+     return ::DotProduct(*this, other);
+   }
+ 
+-  constexpr bool operator==(const FlatGeoPoint &) const noexcept = default;
++  constexpr bool operator==(const FlatGeoPoint &other) const noexcept {
++    return IntPoint2D::operator==(other);
++  }
+ 
+   [[gnu::pure]]
+   bool Sort(const FlatGeoPoint& sp) const noexcept {
+@@ -106,7 +108,9 @@ struct AFlatGeoPoint : public FlatGeoPoint {
+     y = (y >> 2) << 2;
+   }
+ 
+-  constexpr bool operator==(const AFlatGeoPoint &) const noexcept = default;
++  constexpr bool operator==(const AFlatGeoPoint &other) const noexcept {
++    return FlatGeoPoint::operator==(other) && (altitude == other.altitude);
++  }
+ 
+   /**
+    * Ordering operator, used for set ordering.  Uses lexicographic comparison.
+-- 
+2.39.2
+

--- a/recipes-apps/xcsoar/files/0002-replace-defaulted-equality-op-on-PageLayout.patch
+++ b/recipes-apps/xcsoar/files/0002-replace-defaulted-equality-op-on-PageLayout.patch
@@ -1,0 +1,47 @@
+From 44dc2c36375a14c7bfaf467ddaf57dd3e0af7b3d Mon Sep 17 00:00:00 2001
+From: bomilkar <ronald_niederhagen@freenet.de>
+Date: Sun, 9 Jun 2024 12:08:46 +0200
+Subject: [PATCH 2/3] replace defaulted equality op on PageLayout
+
+---
+ src/PageSettings.hpp | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/src/PageSettings.hpp b/src/PageSettings.hpp
+index 3f5b351665..b7993b248e 100644
+--- a/src/PageSettings.hpp
++++ b/src/PageSettings.hpp
+@@ -33,8 +33,12 @@ struct PageLayout
+       panel = 0;
+     }
+ 
+-    constexpr bool operator==(const InfoBoxConfig &other) const noexcept = default;
+-    constexpr bool operator!=(const InfoBoxConfig &other) const noexcept = default;
++    // constexpr bool operator==(const InfoBoxConfig &other) const noexcept = default;
++    bool operator==(const InfoBoxConfig &other) const {
++      return enabled == other.enabled &&
++        auto_switch == other.auto_switch &&
++        panel == other.panel;
++    }
+   };
+ 
+   bool valid;
+@@ -138,8 +142,13 @@ struct PageLayout
+                          std::span<TCHAR> buffer,
+                          const bool concise=false) const noexcept;
+ 
+-  constexpr bool operator==(const PageLayout &other) const noexcept = default;
+-  constexpr bool operator!=(const PageLayout &other) const noexcept = default;
++  // constexpr bool operator==(const PageLayout &other) const noexcept = default;
++  bool operator==(const PageLayout &other) const {
++    return valid == other.valid &&
++      main == other.main &&
++      bottom == other.bottom &&
++      infobox_config == other.infobox_config;
++  }
+ };
+ 
+ struct PageSettings {
+-- 
+2.39.2
+

--- a/recipes-apps/xcsoar/files/0003-replace-defaulted-equality-op-on-Point2D-and-GeoPoin.patch
+++ b/recipes-apps/xcsoar/files/0003-replace-defaulted-equality-op-on-Point2D-and-GeoPoin.patch
@@ -1,0 +1,48 @@
+From 71ae48a16bd421461ab65af4e82471e414d81c4b Mon Sep 17 00:00:00 2001
+From: bomilkar <ronald_niederhagen@freenet.de>
+Date: Sun, 9 Jun 2024 12:18:53 +0200
+Subject: [PATCH 3/3] replace defaulted equality op on Point2D and GeoPoint
+
+---
+ src/Geo/GeoPoint.hpp | 8 +++++++-
+ src/Math/Point2D.hpp | 5 ++++-
+ 2 files changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/src/Geo/GeoPoint.hpp b/src/Geo/GeoPoint.hpp
+index 153aeaf690..557354011f 100644
+--- a/src/Geo/GeoPoint.hpp
++++ b/src/Geo/GeoPoint.hpp
+@@ -263,7 +263,13 @@ struct GeoPoint {
+   [[gnu::pure]]
+   GeoPoint Middle(const GeoPoint &other) const noexcept;
+ 
+-  constexpr bool operator==(const GeoPoint &) const noexcept = default;
++  // constexpr bool operator==(const GeoPoint &) const noexcept = default;
++  constexpr bool Equals(const GeoPoint other) const noexcept {
++    return longitude == other.longitude && latitude == other.latitude;
++  }
++  constexpr bool operator==(const GeoPoint other) const noexcept {
++    return Equals(other);
++  }
+ };
+ 
+ static_assert(std::is_trivial<GeoPoint>::value, "type is not trivial");
+diff --git a/src/Math/Point2D.hpp b/src/Math/Point2D.hpp
+index 4e08b34c26..f291901769 100644
+--- a/src/Math/Point2D.hpp
++++ b/src/Math/Point2D.hpp
+@@ -32,7 +32,10 @@ struct Point2D {
+     :x(static_cast<scalar_type>(src.x)),
+      y(static_cast<scalar_type>(src.y)) {}
+ 
+-  constexpr bool operator==(const Point2D<T, PT> &) const noexcept = default;
++  // constexpr bool operator==(const Point2D<T, PT> &) const noexcept = default;
++  constexpr bool operator==(const Point2D<T, PT> &other) const noexcept {
++    return x == other.x && y == other.y;
++  }
+ 
+   constexpr Point2D<T, PT> operator+(Point2D<T, PT> other) const noexcept {
+     return { scalar_type(x + other.x), scalar_type(y + other.y) };
+-- 
+2.39.2
+

--- a/recipes-apps/xcsoar/xcsoar-testing_git.bb
+++ b/recipes-apps/xcsoar/xcsoar-testing_git.bb
@@ -53,6 +53,7 @@ SRC_URI = " \
 	file://0001-avoid-tail-cut.patch \
 	file://0007-Disable-touch-screen-auto-detection.patch \
 	file://0001-FreeVario.patch \
+	file://0002-replace-defaulted-equality-comparison.patch \
 	file://ov-xcsoar.conf \
 "
 

--- a/recipes-apps/xcsoar/xcsoar-testing_git.bb
+++ b/recipes-apps/xcsoar/xcsoar-testing_git.bb
@@ -54,6 +54,8 @@ SRC_URI = " \
 	file://0007-Disable-touch-screen-auto-detection.patch \
 	file://0001-FreeVario.patch \
 	file://0002-replace-defaulted-equality-comparison.patch \
+	file://0002-replace-defaulted-equality-op-on-PageLayout.patch \
+	file://0003-replace-defaulted-equality-op-on-Point2D-and-GeoPoin.patch \
 	file://ov-xcsoar.conf \
 "
 


### PR DESCRIPTION
This PR addresses https://github.com/XCSoar/XCSoar/issues/1253

g++ version 10.2 does not implement the default “operator==” construct in the same way as g++ version 12. This becomes clear if you replace the default “operator==” with the explicit “operator==” declaration: it solves Issue #375 and the issue 1253 reported against XCSoar.

Defaulted equality comparison, a C++-20 feature, is used in XCSoar:
src/Geo/Flat/FlatGeoPoint.hpp
This is addressed in the first commit.

There are other files using defaulted “operator==” constructs:
src/Math/Point2D.hpp
src/Geo/GeoPoint.hpp
src/PageSettings.hpp
Instances in these 3 files have not been identified as root causes to other Issues. I still recommend to apply the patches just to be safe. These changes are in a separate commit.

This PR will be obsolete as soon at the OV build deploys compiler version g++-12 (or later).

