### PR TITLE
CM4: change screen rotation, activate i2c

### DIFF
--- a/conf/machine/ov-cm4-57-lvds.conf
+++ b/conf/machine/ov-cm4-57-lvds.conf
@@ -36,6 +36,8 @@ UBOOT_MACHINE = "rpi_arm64_config"
 #Enable u-boot
 RPI_USE_U_BOOT = "1"
 ENABLE_UART = "1"
+#Enable otg mode
+ENABLE_DWC2_HOST = "1"
 
 VC4DTBO ?= "vc4-kms-v3d"
 

--- a/conf/machine/ov-cm4-7-pq070.conf
+++ b/conf/machine/ov-cm4-7-pq070.conf
@@ -36,6 +36,8 @@ UBOOT_MACHINE = "rpi_arm64_config"
 #Enable u-boot
 RPI_USE_U_BOOT = "1"
 ENABLE_UART = "1"
+#Enable otg mode
+ENABLE_DWC2_HOST = "1"
 
 VC4DTBO ?= "vc4-kms-v3d"
 

--- a/conf/machine/ov-rpi4-64.conf
+++ b/conf/machine/ov-rpi4-64.conf
@@ -36,6 +36,8 @@ UBOOT_MACHINE = "rpi_arm64_config"
 #Enable u-boot
 RPI_USE_U_BOOT = "1"
 ENABLE_UART = "1"
+#Enable otg mode
+ENABLE_DWC2_HOST = "1"
 
 VC4DTBO ?= "vc4-kms-v3d"
 

--- a/conf/machine/ov-rpi4.conf
+++ b/conf/machine/ov-rpi4.conf
@@ -24,6 +24,8 @@ RPI_KERNEL_DEVICETREE ?= " \
 # Enable U-boot
 RPI_USE_U_BOOT = "1"
 ENABLE_UART = "1"
+#Enable otg mode
+ENABLE_DWC2_HOST = "1"
 
 # 'l' stands for LPAE
 SDIMG_KERNELIMAGE ?= "kernel7l.img"

--- a/recipes-apps/ovmenu-ng/files/ovmenu-ng-rpi.sh
+++ b/recipes-apps/ovmenu-ng/files/ovmenu-ng-rpi.sh
@@ -1,0 +1,434 @@
+#!/bin/bash
+
+#Config
+TIMEOUT=3
+INPUT=/tmp/menu.sh.$$
+
+# trap and delete temp files
+trap "rm $INPUT;rm /tmp/tail.$$; exit" SIGHUP SIGINT SIGTERM
+
+main_menu () {
+while true
+do
+	### display main menu ###
+	dialog --clear --nocancel --backtitle "OpenVario" \
+	--title "[ M A I N - M E N U ]" \
+	--begin 3 4 \
+	--menu "You can use the UP/DOWN arrow keys" 15 50 6 \
+	XCSoar   "Start XCSoar" \
+	File   "Copys file to and from OpenVario" \
+	System   "Update, Settings, ..." \
+	Exit   "Exit to the shell" \
+	Restart "Restart" \
+	Power_OFF "Power OFF" 2>"${INPUT}"
+
+	menuitem=$(<"${INPUT}")
+
+	# make decsion
+case $menuitem in
+	XCSoar) start_xcsoar;;
+	File) submenu_file;;
+	System) submenu_system;;
+	Exit) yesno_exit;;
+	Restart) yesno_restart;;
+	Power_OFF) yesno_power_off;;
+esac
+
+done
+}
+
+function submenu_file() {
+
+	### display file menu ###
+	dialog --nocancel --backtitle "OpenVario" \
+	--title "[ F I L E ]" \
+	--begin 3 4 \
+	--menu "You can use the UP/DOWN arrow keys" 15 50 4 \
+	Download_IGC   "Download XCSoar IGC files to USB" \
+	Download   "Download XCSoar to USB" \
+	Upload   "Upload files from USB to XCSoar" \
+	Back   "Back to Main" 2>"${INPUT}"
+
+	menuitem=$(<"${INPUT}")
+
+	# make decsion
+	case $menuitem in
+		Download_IGC) download_igc_files;;
+		Download) download_files;;
+		Upload) upload_files;;
+		Exit) ;;
+esac
+}
+
+function submenu_system() {
+	### display system menu ###
+	dialog --nocancel --backtitle "OpenVario" \
+	--title "[ S Y S T E M ]" \
+	--begin 3 4 \
+	--menu "You can use the UP/DOWN arrow keys" 15 50 6 \
+	Update_System   "Update system software" \
+	Update_Maps   "Update Maps files" \
+	Calibrate_Sensors   "Calibrate Sensors" \
+	Calibrate_Touch   "Calibrate Touch" \
+	Settings   "System Settings" \
+	Information "System Info" \
+	Back   "Back to Main" 2>"${INPUT}"
+
+	menuitem=$(<"${INPUT}")
+
+	# make decsion
+	case $menuitem in
+		Update_System)
+			update_system
+			;;
+		Update_Maps)
+			update_maps
+			;;
+		Calibrate_Sensors)
+			calibrate_sensors
+			;;
+		Calibrate_Touch)
+			calibrate_touch
+			;;
+		Settings)
+			submenu_settings
+			;;
+		Information)
+			show_info
+			;;
+		Exit) ;;
+	esac
+}
+
+function show_info() {
+	### collect info of system
+	XCSOAR_VERSION=$(opkg list-installed xcsoar | awk -F' ' '{print $3}')
+	XCSOAR_MAPS_VERSION=$(opkg list-installed | grep "xcsoar-maps-" | awk -F' ' '{print $3}')
+	IMAGE_VERSION=$(cat /etc/os-release | grep VERSION_ID | awk -F'=' -F'"' '{print $2}')
+	SENSORD_VERSION=$(opkg list-installed sensord* | awk -F' ' '{print $3}')
+	VARIOD_VERSION=$(opkg list-installed variod* | awk -F' ' '{print $3}')
+	IP_ETH0=$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
+	IP_WLAN=$(/sbin/ifconfig wlan0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
+
+	dialog --backtitle "OpenVario" \
+	--title "[ S Y S T E M I N F O ]" \
+	--begin 3 4 \
+	--msgbox " \
+	\n \
+	Image: $IMAGE_VERSION\n \
+	XCSoar: $XCSOAR_VERSION\n \
+	Maps: $XCSOAR_MAPS_VERSION\n \
+	sensord: $SENSORD_VERSION\n \
+	variod: $VARIOD_VERSION\n \
+	IP eth0: $IP_ETH0\n \
+	IP wlan0: $IP_WLAN\n \
+	" 15 50
+
+}
+
+function submenu_settings() {
+	### display settings menu ###
+	dialog --nocancel --backtitle "OpenVario" \
+	--title "[ S Y S T E M ]" \
+	--begin 3 4 \
+	--menu "You can use the UP/DOWN arrow keys" 15 50 5 \
+	Display_Rotation 	"Set rotation of the display" \
+	LCD_Brightness		"Set display brightness" \
+	XCSoar_Language 	"Set language used for XCSoar" \
+	SSH			"Enable or disable SSH" \
+	Back   "Back to Main" 2>"${INPUT}"
+
+	menuitem=$(<"${INPUT}")
+
+	# make decsion
+	case $menuitem in
+		Display_Rotation)
+			submenu_rotation
+			;;
+		LCD_Brightness)
+			submenu_lcd_brightness
+			;;
+		XCSoar_Language)
+			submenu_xcsoar_lang
+			;;
+		SSH)
+			submenu_ssh
+			;;
+		Back) ;;
+	esac
+}
+
+function submenu_xcsoar_lang() {
+	if test -n "$LANG"; then
+		XCSOAR_LANG="$LANG"
+	else
+		XCSOAR_LANG="system"
+	fi
+
+	dialog --nocancel --backtitle "OpenVario" \
+		--title "[ S Y S T E M ]" \
+		--begin 3 4 \
+		--menu "Actual Setting is $XCSOAR_LANG \nSelect Language:" 15 50 12 \
+		 system "Default system" \
+		 de_DE.UTF-8 "German" \
+		 fr_FR.UTF-8 "France" \
+		 it_IT.UTF-8 "Italian" \
+		 hu_HU.UTF-8 "Hungary" \
+		 pl_PL.UTF-8 "Poland" \
+		 cs_CZ.UTF-8 "Czech" \
+		 sk_SK.UTF-8 "Slowak" \
+		 lt_LT.UTF-8 "Lithuanian" \
+		 ru_RU.UTF-8 "Russian" \
+		 es_ES.UTF-8 "Espanol" \
+		 nl_NL.UTF-8 "Dutch" \
+		 2>"${INPUT}"
+
+	menuitem=$(<"${INPUT}")
+
+	# update config
+	localectl set-locale "$menuitem"
+	sync
+
+	export LANG="$menuitem"
+}
+
+function submenu_ssh() {
+	if /bin/systemctl --quiet is-enabled dropbear.socket; then
+		local state=enabled
+	elif /bin/systemctl --quiet is-active dropbear.socket; then
+		local state=temporary
+	else
+		local state=disabled
+	fi
+
+	dialog --nocancel --backtitle "OpenVario" \
+		--title "[ S S H ]" \
+		--begin 3 4 \
+		--default-item "${state}" \
+		--menu "SSH access is currently ${state}." 15 50 4 \
+		enabled "Enable SSH permanently" \
+		temporary "Enable SSH temporarily (until reboot)" \
+		disabled "Disable SSH" \
+		2>"${INPUT}"
+	menuitem=$(<"${INPUT}")
+
+	if test "${state}" != "$menuitem"; then
+		if test "$menuitem" = "enabled"; then
+			/bin/systemctl enable --now dropbear.socket
+		elif test "$menuitem" = "temporary"; then
+			/bin/systemctl disable dropbear.socket
+			/bin/systemctl start dropbear.socket
+		else
+			/bin/systemctl disable --now dropbear.socket
+		fi
+	fi
+}
+
+function submenu_lcd_brightness() {
+while [ $? -eq 0 ]
+do
+	menuitem=$(</sys/class/backlight/lcd/brightness)
+	dialog --backtitle "OpenVario" \
+	--title "LCD brightness" \
+	--cancel-label Back \
+	--ok-label Set \
+	--default-item "${menuitem}" \
+	--menu "Brightness value" \
+	17 50 10 \
+	1 "Dark" \
+	2 "" \
+	3 "" \
+	4 "" \
+	5 "Medium" \
+	6 "" \
+	7 "" \
+	8 "" \
+	9 "" \
+	10 "Bright" \
+	2>/sys/class/backlight/lcd/brightness
+done
+	submenu_settings
+}
+
+function submenu_rotation() {
+	TEMP=$(grep "rotation" /boot/config.uEnv)
+	if [ -n $TEMP ]; then
+		ROTATION=${TEMP: -1}
+		dialog --nocancel --backtitle "OpenVario" \
+		--title "[ S Y S T E M ]" \
+		--begin 3 4 \
+		--default-item "${ROTATION}" \
+		--menu "Select Rotation:" 15 50 4 \
+		 0 "Landscape 0 deg" \
+		 1 "Portrait 90 deg" \
+		 2 "Landscape 180 deg" \
+		 3 "Portrait 270 deg" 2>"${INPUT}"
+
+		 menuitem=$(<"${INPUT}")
+
+		# update config
+		# uboot rotation
+		sed -i 's/fbcon=rotate:.*/fbcon=rotate:'${menuitem}'/' /boot/cmdline.txt
+		echo "$menuitem" >/sys/class/graphics/fbcon/rotate_all
+		dialog --msgbox "New Setting saved !!\n Touch recalibration required !!" 10 50
+	else
+		dialog --backtitle "OpenVario" \
+		--title "ERROR" \
+		--msgbox "No Config found !!"
+	fi
+}
+
+function update_system() {
+
+	echo "Updating System ..." > /tmp/tail.$$
+	opkg update &>/dev/null
+	OPKG_UPDATE=$(opkg list-upgradable)
+
+	dialog --backtitle "Openvario" \
+	--begin 3 4 \
+	--defaultno \
+	--title "Update" --yesno "$OPKG_UPDATE" 15 40
+
+	response=$?
+	case $response in
+		0) opkg upgrade &>/tmp/tail.$$
+		sync
+		dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
+		;;
+	esac
+}
+
+function calibrate_sensors() {
+
+	dialog --backtitle "Openvario" \
+	--begin 3 4 \
+	--defaultno \
+	--title "Sensor Calibration" --yesno "Really want to calibrate sensors ?? \n This takes a few moments ...." 10 40
+
+	response=$?
+	case $response in
+		0) ;;
+		*) return 0
+	esac
+
+	echo "Calibrating Sensors ..." >> /tmp/tail.$$
+	systemctl stop variod.service sensord.socket 'sensord@*.service'
+	/opt/bin/sensorcal -c > /tmp/tail.$$
+
+	if [ $? -eq 2 ]
+	then
+		# board not initialised
+		dialog --backtitle "Openvario" \
+		--begin 3 4 \
+		--defaultno \
+		--title "Init Sensorboard" --yesno "Sensorboard is virgin ! \n Do you want to initialize ??" 10 40
+
+		response=$?
+		case $response in
+			0) /opt/bin/sensorcal -i > /tmp/tail.$$
+			;;
+		esac
+		echo "Please run sensorcal again !!!" > /tmp/tail.$$
+	fi
+	sync
+	dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
+	systemctl restart variod.service
+}
+
+function calibrate_touch() {
+	echo "Calibrating Touch ..." >> /tmp/tail.$$
+	/usr/bin/ov-calibrate-ts.sh >> /tmp/tail.$$
+	dialog --msgbox "Calibration OK!" 10 50
+}
+
+# Copy /usb/usbstick/openvario/maps to /home/root/.xcsoar
+# Copy only xcsoar-maps*.ipk and *.xcm files
+function update_maps() {
+	echo "Updating Maps ..." > /tmp/tail.$$
+	/usr/bin/update-maps.sh >> /tmp/tail.$$ 2>/dev/null &
+	dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
+}
+
+# Copy /home/root/.xcsoar to /usb/usbstick/openvario/download/xcsoar
+function download_files() {
+	echo "Downloading files ..." > /tmp/tail.$$
+	/usr/bin/download-all.sh >> /tmp/tail.$$ &
+	dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
+}
+
+# Copy /home/root/.xcsoar/logs to /usb/usbstick/openvario/igc
+# Copy only *.igc files
+function download_igc_files() {
+	/usr/bin/download-igc.sh
+}
+
+# Copy /usb/usbstick/openvario/upload to /home/root/.xcsoar
+function upload_files(){
+	echo "Uploading files ..." > /tmp/tail.$$
+	/usr/bin/upload-xcsoar.sh >> /tmp/tail.$$ &
+	dialog --backtitle "OpenVario" --title "Result" --tailbox /tmp/tail.$$ 30 50
+}
+
+function start_xcsoar() {
+	/usr/bin/xcsoar -fly
+	sync
+}
+
+function yesno_exit(){
+	dialog --backtitle "Openvario" \
+	--begin 3 4 \
+	--defaultno \
+	--title "Really exit ?" --yesno "Really want to go to console ??" 5 40
+
+	response=$?
+	case $response in
+		0)
+			clear
+			cd
+
+			# Redirecting stderr to stdout (= the console)
+			# because stderr is currently connected to
+			# systemd-journald, which breaks interactive
+			# shells.
+			if test -x /bin/bash; then
+				/bin/bash --login 2>&1
+			elif test -x /bin/ash; then
+				/bin/ash -i 2>&1
+			else
+				/bin/sh 2>&1
+			fi
+			;;
+	esac
+}
+
+function yesno_restart(){
+	dialog --backtitle "Openvario" \
+	--begin 3 4 \
+	--defaultno \
+	--title "Really restart ?" --yesno "Really want to restart ??" 5 40
+
+	response=$?
+	case $response in
+		0) reboot;;
+	esac
+}
+
+function yesno_power_off(){
+	dialog --backtitle "Openvario" \
+	--begin 3 4 \
+	--defaultno \
+	--title "Really Power-OFF ?" --yesno "Really want to Power-OFF" 5 40
+
+	response=$?
+	case $response in
+		0) shutdown -h now;;
+	esac
+}
+
+DIALOG_CANCEL=1 dialog --nook --nocancel --pause "Starting XCSoar ... \\n Press [ESC] for menu" 10 30 $TIMEOUT 2>&1
+
+case $? in
+	0) start_xcsoar;;
+	*) main_menu;;
+esac
+main_menu

--- a/recipes-apps/ovmenu-ng/ovmenu-ng_0.1.bb
+++ b/recipes-apps/ovmenu-ng/ovmenu-ng_0.1.bb
@@ -29,6 +29,7 @@ RCONFLICTS:${PN} = " \
 
 SRC_URI =      "\
 	file://ovmenu-ng.sh \
+	file://ovmenu-ng-rpi.sh \
 	file://openvario.rc \
 	file://${BPN}.service \
 	file://disable_dropbear.preset \
@@ -43,7 +44,14 @@ do_compile() {
 
 do_install() {
 	install -d ${D}/${bindir}
-	install -m 0755 ${S}/ovmenu-ng.sh ${D}/${bindir}
+	case "${MACHINE}" in
+		ov-cm4-*|ov-rpi4*)
+			install -m 0755 ${S}/ovmenu-ng-rpi.sh ${D}${bindir}/ovmenu-ng.sh
+			;;
+		*)
+			install -m 0755 ${S}/ovmenu-ng.sh ${D}${bindir}/ovmenu-ng.sh
+			;;
+	esac
 	install -d ${D}${ROOT_HOME}
 	install -m 0755 ${S}/openvario.rc ${D}${ROOT_HOME}/.dialogrc
 	install -d ${D}${systemd_unitdir}/system
@@ -52,7 +60,7 @@ do_install() {
 	# TODO: move this preset file to a more appropriate recipe
 	install -d ${D}${systemd_unitdir}/system-preset
 	install -m 0644 ${WORKDIR}/disable_dropbear.preset ${D}${systemd_unitdir}/system-preset/50-disable_dropbear.preset
-}
+} 
 
 SYSTEMD_SERVICE:${PN} = "${PN}.service"
 

--- a/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,0 +1,5 @@
+SUMMARY = "cmdline.txt file used to boot the kernel on a Raspberry Pi device"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+CMDLINE:append = "fbcon=rotate:0" 

--- a/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -10,9 +10,6 @@ do_deploy:append () {
         # Use the machine specific device tree overlay
         echo "# Enable 57 LVDS" >> $CONFIG
         echo "dtoverlay=ov-rpi4-57-lvds" >> $CONFIG
-        
-        # Enable OTG mode
-        echo "otg_mode=1" >> $CONFIG
     fi
     
      # Openvario 57 LVDS
@@ -20,9 +17,6 @@ do_deploy:append () {
         # Use the machine specific device tree overlay
         echo "# Enable 57 LVDS" >> $CONFIG
         echo "dtoverlay=ov-cm4-57-lvds" >> $CONFIG
-        
-        # Enable OTG mode
-        echo "otg_mode=1" >> $CONFIG
     fi
 
     # Openvario 7 PQ070
@@ -30,8 +24,5 @@ do_deploy:append () {
         # Use the machine specific device tree overlay
         echo "# Enable PQ070 Display" >> $CONFIG
         echo "dtoverlay=ov-cm4-7-pq070" >> $CONFIG
-
-        # Enable OTG mode
-        echo "otg_mode=1" >> $CONFIG
     fi
 }

--- a/recipes-kernel/linux/linux-ov-rpi_6.6.bb
+++ b/recipes-kernel/linux/linux-ov-rpi_6.6.bb
@@ -29,7 +29,6 @@ SRC_URI = "git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RP
            ${@bb.utils.contains("MACHINE_FEATURES", "wm8960", "file://wm8960.cfg", "", d)} \
            file://default-cpu-governor.cfg \
            file://rpi4-nvmem.cfg \
-           file://rpi4-nvmem.cfg \
            file://0001-Added-openvario-overlays.patch \
            file://ov-cm4-57-lvds-overlay.dts;subdir=git/arch/arm/boot/dts/overlays \
            file://ov-cm4-7-pq070-overlay.dts;subdir=git/arch/arm/boot/dts/overlays \
@@ -47,6 +46,7 @@ KBUILD_DEFCONFIG:raspberrypi4-64 ?= "bcm2711_defconfig"
 LINUX_VERSION_EXTENSION ?= ""
 
 KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "stmpe-ts", "", d)}"
+KERNEL_MODULE_AUTOLOAD:rpi += "i2c-dev i2c-bcm2708"
 
 # A LOADADDR is needed when building a uImage format kernel. This value is not
 # set by default in rpi-4.8.y and later branches so we need to provide it


### PR DESCRIPTION
Adding I2C to enable communication with the sensorboard

The XCSoar version needs to be updated to integrate the fix for the CM4 platform for issue Openvario/meta-openvario#387.

The rotation part might be a change for the CM4 platform but could affect the cubieboard build: any comments?

Move otg_mode from bootfiles to machine configs

Part of #396