### PR TITLE
CM4: Add serial interfaces and sound driver

### DIFF
--- a/conf/machine/ov-cm4-57-lvds.conf
+++ b/conf/machine/ov-cm4-57-lvds.conf
@@ -7,6 +7,7 @@ require conf/machine/include/arm/armv8a/tune-cortexa72.inc
 
 RPI_KERNEL_DEVICETREE_OVERLAYS:append = " \
     overlays/ov-cm4-57-lvds.dtbo \
+    overlays/max98357a.dtbo \
 "
 
 KBUILD_DEFCONFIG:ov-rpi4-64 ?= "bcm2711_defconfig"

--- a/conf/machine/ov-cm4-7-pq070.conf
+++ b/conf/machine/ov-cm4-7-pq070.conf
@@ -7,6 +7,7 @@ require conf/machine/include/arm/armv8a/tune-cortexa72.inc
 
 RPI_KERNEL_DEVICETREE_OVERLAYS:append = " \
     overlays/ov-cm4-7-pq070.dtbo \
+    overlays/max98357a.dtbo \
 "
 
 KBUILD_DEFCONFIG:ov-rpi4-64 ?= "bcm2711_defconfig"

--- a/conf/machine/ov-rpi4-64.conf
+++ b/conf/machine/ov-rpi4-64.conf
@@ -7,6 +7,7 @@ require conf/machine/include/arm/armv8a/tune-cortexa72.inc
 
 RPI_KERNEL_DEVICETREE_OVERLAYS:append = " \
     overlays/ov-rpi4-57-lvds.dtbo \
+    overlays/max98357a.dtbo \
 "
 
 KBUILD_DEFCONFIG:ov-rpi4-64 ?= "bcm2711_defconfig"

--- a/conf/machine/ov-rpi4.conf
+++ b/conf/machine/ov-rpi4.conf
@@ -10,6 +10,9 @@ require conf/machine/include/arm/armv7a/tune-cortexa7.inc
 #RPI_KERNEL_DEVICETREE_OVERLAYS:append = " \
 #    overlays/ov-rpi4-57-lvds.dtbo \
 #"
+RPI_KERNEL_DEVICETREE_OVERLAYS:append = " \
+    overlays/max98357a.dtbo \
+"
 
 KBUILD_DEFCONFIG:ov-rpi4 ?= "bcm2711_defconfig"
 

--- a/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -25,4 +25,11 @@ do_deploy:append () {
         echo "# Enable PQ070 Display" >> $CONFIG
         echo "dtoverlay=ov-cm4-7-pq070" >> $CONFIG
     fi
+
+    echo "# sound driver" >> $CONFIG
+    echo "dtoverlay=max98357a" >> $CONFIG
+
+    echo "# serial interfaces" >> $CONFIG
+    echo "dtoverlay=uart2" >> $CONFIG
+    echo "dtoverlay=uart3" >> $CONFIG
 }


### PR DESCRIPTION
Add serial interfaces and sound driver

`RPI_KERNEL_DEVICETREE_OVERLAYS` are missing in `ov-rpi4.conf` -> why?

Part of #396