### PR TITLE
Add CM4 machines to conf-notes

### DIFF
--- a/conf/templates/default/conf-notes.txt
+++ b/conf/templates/default/conf-notes.txt
@@ -11,6 +11,8 @@ Possible machines are:
     ov-cb2-7-ch070-ds2
     ov-cb2-7-pq070
     ov-cb2-7-pq070-ds2
+    ov-cm4-7-pq070
+    ov-cm4-57-lvds
     ov-rpi4
     ov-rpi4-64
 


### PR DESCRIPTION
The CM4 machines are listed on the Openvario repo and avilable in the `machines` directory but are not listed in the output of `source openembedded-core/oe-init-build-env .`