### PR TITLE
RPi4: move common configuration to top-level machine

### DIFF
--- a/conf/machine/ov-cm4-57-lvds.conf
+++ b/conf/machine/ov-cm4-57-lvds.conf
@@ -2,54 +2,17 @@
 #@NAME: RaspberryPi 4 Development Board (64bit)
 #@DESCRIPTION: Machine configuration for the RaspberryPi 4 in 64 bits mode
 
-MACHINEOVERRIDES =. "raspberrypi4:"
-
-MACHINE_FEATURES += "pci"
-MACHINE_EXTRA_RRECOMMENDS += "\
-    linux-firmware-rpidistro-bcm43455 \
-    bluez-firmware-rpidistro-bcm4345c0-hcd \
-    linux-firmware-rpidistro-bcm43456 \
-    bluez-firmware-rpidistro-bcm4345c5-hcd \
-"
-
+require ov-raspberrypi4.inc
 require conf/machine/include/arm/armv8a/tune-cortexa72.inc
-include conf/machine/include/rpi-base.inc
 
-RPI_KERNEL_DEVICETREE = " \
-    broadcom/bcm2711-rpi-4-b.dtb \
-    broadcom/bcm2711-rpi-400.dtb \
-    broadcom/bcm2711-rpi-cm4.dtb \
-    broadcom/bcm2711-rpi-cm4s.dtb \
-"
 RPI_KERNEL_DEVICETREE_OVERLAYS:append = " \
     overlays/ov-cm4-57-lvds.dtbo \
-    "
+"
 
 KBUILD_DEFCONFIG:ov-rpi4-64 ?= "bcm2711_defconfig"
-PREFERRED_PROVIDER_virtual/kernel = "linux-ov-rpi"
 
 SDIMG_KERNELIMAGE ?= "kernel8.img"
-SERIAL_CONSOLES ?= "115200;ttyS0"
 
 UBOOT_MACHINE = "rpi_arm64_config"
 
-#Enable u-boot
-RPI_USE_U_BOOT = "1"
-ENABLE_UART = "1"
-#Enable otg mode
-ENABLE_DWC2_HOST = "1"
-
-VC4DTBO ?= "vc4-kms-v3d"
-
-# When u-boot is enabled we need to use the "Image" format and the "booti"
-# command to load the kernel
-KERNEL_IMAGETYPE_UBOOT ?= "Image"
-# "zImage" not supported on arm64 and ".gz" images not supported by bootloader yet
-KERNEL_IMAGETYPE_DIRECT ?= "Image"
-KERNEL_BOOTCMD ?= "booti"
-
 ARMSTUB ?= "armstub8-gic.bin"
-
-#ov-rpi-sdimg
-IMAGE_CLASSES += "sdcard_image-ov-rpi"
-IMAGE_FSTYPES = "tar.bz2 ext3 wic.bz2 wic.bmap ov-rpi-sdimg"

--- a/conf/machine/ov-cm4-7-pq070.conf
+++ b/conf/machine/ov-cm4-7-pq070.conf
@@ -2,54 +2,17 @@
 #@NAME: RaspberryPi 4 Development Board (64bit)
 #@DESCRIPTION: Machine configuration for the RaspberryPi 4 in 64 bits mode
 
-MACHINEOVERRIDES =. "raspberrypi4:"
-
-MACHINE_FEATURES += "pci"
-MACHINE_EXTRA_RRECOMMENDS += "\
-    linux-firmware-rpidistro-bcm43455 \
-    bluez-firmware-rpidistro-bcm4345c0-hcd \
-    linux-firmware-rpidistro-bcm43456 \
-    bluez-firmware-rpidistro-bcm4345c5-hcd \
-"
-
+require ov-raspberrypi4.inc
 require conf/machine/include/arm/armv8a/tune-cortexa72.inc
-include conf/machine/include/rpi-base.inc
 
-RPI_KERNEL_DEVICETREE = " \
-    broadcom/bcm2711-rpi-4-b.dtb \
-    broadcom/bcm2711-rpi-400.dtb \
-    broadcom/bcm2711-rpi-cm4.dtb \
-    broadcom/bcm2711-rpi-cm4s.dtb \
-"
 RPI_KERNEL_DEVICETREE_OVERLAYS:append = " \
     overlays/ov-cm4-7-pq070.dtbo \
-    "
+"
 
 KBUILD_DEFCONFIG:ov-rpi4-64 ?= "bcm2711_defconfig"
-PREFERRED_PROVIDER_virtual/kernel = "linux-ov-rpi"
 
 SDIMG_KERNELIMAGE ?= "kernel8.img"
-SERIAL_CONSOLES ?= "115200;ttyS0"
 
 UBOOT_MACHINE = "rpi_arm64_config"
 
-#Enable u-boot
-RPI_USE_U_BOOT = "1"
-ENABLE_UART = "1"
-#Enable otg mode
-ENABLE_DWC2_HOST = "1"
-
-VC4DTBO ?= "vc4-kms-v3d"
-
-# When u-boot is enabled we need to use the "Image" format and the "booti"
-# command to load the kernel
-KERNEL_IMAGETYPE_UBOOT ?= "Image"
-# "zImage" not supported on arm64 and ".gz" images not supported by bootloader yet
-KERNEL_IMAGETYPE_DIRECT ?= "Image"
-KERNEL_BOOTCMD ?= "booti"
-
 ARMSTUB ?= "armstub8-gic.bin"
-
-#ov-rpi-sdimg
-IMAGE_CLASSES += "sdcard_image-ov-rpi"
-IMAGE_FSTYPES = "tar.bz2 ext3 wic.bz2 wic.bmap"

--- a/conf/machine/ov-raspberrypi4.inc
+++ b/conf/machine/ov-raspberrypi4.inc
@@ -1,0 +1,43 @@
+# Common machine definitions for all Raspberry Pi4-based OpenVarios
+
+MACHINEOVERRIDES =. "raspberrypi4:"
+
+MACHINE_FEATURES += "pci"
+MACHINE_EXTRA_RRECOMMENDS += "\
+    linux-firmware-rpidistro-bcm43455 \
+    bluez-firmware-rpidistro-bcm4345c0-hcd \
+    linux-firmware-rpidistro-bcm43456 \
+    bluez-firmware-rpidistro-bcm4345c5-hcd \
+"
+
+include conf/machine/include/rpi-base.inc
+
+RPI_KERNEL_DEVICETREE = " \
+    broadcom/bcm2711-rpi-4-b.dtb \
+    broadcom/bcm2711-rpi-400.dtb \
+    broadcom/bcm2711-rpi-cm4.dtb \
+    broadcom/bcm2711-rpi-cm4s.dtb \
+"
+
+PREFERRED_PROVIDER_virtual/kernel = "linux-ov-rpi"
+
+SERIAL_CONSOLES ?= "115200;ttyS0"
+
+#Enable u-boot
+RPI_USE_U_BOOT = "1"
+ENABLE_UART = "1"
+#Enable otg mode
+ENABLE_DWC2_HOST = "1"
+
+VC4DTBO ?= "vc4-kms-v3d"
+
+# When u-boot is enabled we need to use the "Image" format and the "booti"
+# command to load the kernel
+KERNEL_IMAGETYPE_UBOOT ?= "Image"
+# "zImage" not supported on arm64 and ".gz" images not supported by bootloader yet
+KERNEL_IMAGETYPE_DIRECT ?= "Image"
+KERNEL_BOOTCMD ?= "booti"
+
+#ov-rpi-sdimg
+IMAGE_CLASSES += "sdcard_image-ov-rpi"
+IMAGE_FSTYPES = "tar.bz2 ext3 wic.bz2 wic.bmap ov-rpi-sdimg"

--- a/conf/machine/ov-rpi4-64.conf
+++ b/conf/machine/ov-rpi4-64.conf
@@ -2,54 +2,17 @@
 #@NAME: RaspberryPi 4 Development Board (64bit)
 #@DESCRIPTION: Machine configuration for the RaspberryPi 4 in 64 bits mode
 
-MACHINEOVERRIDES =. "raspberrypi4:"
-
-MACHINE_FEATURES += "pci"
-MACHINE_EXTRA_RRECOMMENDS += "\
-    linux-firmware-rpidistro-bcm43455 \
-    bluez-firmware-rpidistro-bcm4345c0-hcd \
-    linux-firmware-rpidistro-bcm43456 \
-    bluez-firmware-rpidistro-bcm4345c5-hcd \
-"
-
+require ov-raspberrypi4.inc
 require conf/machine/include/arm/armv8a/tune-cortexa72.inc
-include conf/machine/include/rpi-base.inc
 
-RPI_KERNEL_DEVICETREE = " \
-    broadcom/bcm2711-rpi-4-b.dtb \
-    broadcom/bcm2711-rpi-400.dtb \
-    broadcom/bcm2711-rpi-cm4.dtb \
-    broadcom/bcm2711-rpi-cm4s.dtb \
-"
 RPI_KERNEL_DEVICETREE_OVERLAYS:append = " \
     overlays/ov-rpi4-57-lvds.dtbo \
-    "
+"
 
 KBUILD_DEFCONFIG:ov-rpi4-64 ?= "bcm2711_defconfig"
-PREFERRED_PROVIDER_virtual/kernel = "linux-ov-rpi"
 
 SDIMG_KERNELIMAGE ?= "kernel8.img"
-SERIAL_CONSOLES ?= "115200;ttyS0"
 
 UBOOT_MACHINE = "rpi_arm64_config"
 
-#Enable u-boot
-RPI_USE_U_BOOT = "1"
-ENABLE_UART = "1"
-#Enable otg mode
-ENABLE_DWC2_HOST = "1"
-
-VC4DTBO ?= "vc4-kms-v3d"
-
-# When u-boot is enabled we need to use the "Image" format and the "booti"
-# command to load the kernel
-KERNEL_IMAGETYPE_UBOOT ?= "Image"
-# "zImage" not supported on arm64 and ".gz" images not supported by bootloader yet
-KERNEL_IMAGETYPE_DIRECT ?= "Image"
-KERNEL_BOOTCMD ?= "booti"
-
 ARMSTUB ?= "armstub8-gic.bin"
-
-#ov-rpi-sdimg
-IMAGE_CLASSES += "sdcard_image-ov-rpi"
-IMAGE_FSTYPES = "tar.bz2 ext3 wic.bz2 wic.bmap ov-rpi-sdimg"

--- a/conf/machine/ov-rpi4.conf
+++ b/conf/machine/ov-rpi4.conf
@@ -3,8 +3,6 @@
 #@DESCRIPTION: Machine configuration for Openvario Hardare based on the RaspberryPi 4 in 32 bit mode
 
 DEFAULTTUNE ?= "cortexa7thf-neon-vfpv4"
-require conf/machine/include/arm/armv7a/tune-cortexa7.inc
-include conf/machine/include/rpi-base.inc
 
 MACHINE_FEATURES += "pci"
 MACHINE_EXTRA_RRECOMMENDS += "\
@@ -14,6 +12,9 @@ MACHINE_EXTRA_RRECOMMENDS += "\
     bluez-firmware-rpidistro-bcm4345c5-hcd \
 "
 
+require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+include conf/machine/include/rpi-base.inc
+
 KBUILD_DEFCONFIG:ov-rpi4 ?= "bcm2711_defconfig"
 
 RPI_KERNEL_DEVICETREE ?= " \
@@ -21,19 +22,22 @@ RPI_KERNEL_DEVICETREE ?= " \
     broadcom/bcm2711-rpi-cm4.dtb \
     broadcom/bcm2711-rpi-cm4s.dtb \
     "
-# Enable U-boot
+
+# 'l' stands for LPAE
+SDIMG_KERNELIMAGE ?= "kernel7l.img"
+SERIAL_CONSOLES ?= "115200;ttyS0"
+
+UBOOT_MACHINE = "rpi_4_32b_config"
+
+#Enable u-boot
 RPI_USE_U_BOOT = "1"
 ENABLE_UART = "1"
 #Enable otg mode
 ENABLE_DWC2_HOST = "1"
 
-# 'l' stands for LPAE
-SDIMG_KERNELIMAGE ?= "kernel7l.img"
-UBOOT_MACHINE = "rpi_4_32b_config"
-SERIAL_CONSOLES ?= "115200;ttyS0"
-
 VC4DTBO ?= "vc4-kms-v3d"
 ARMSTUB ?= "armstub7.bin"
 
+#ov-rpi-sdimg
 IMAGE_CLASSES += "sdcard_image-ov-rpi"
 IMAGE_FSTYPES = "tar.bz2 ext3 wic.bz2 wic.bmap ov-rpi-sdimg"

--- a/conf/machine/ov-rpi4.conf
+++ b/conf/machine/ov-rpi4.conf
@@ -4,40 +4,18 @@
 
 DEFAULTTUNE ?= "cortexa7thf-neon-vfpv4"
 
-MACHINE_FEATURES += "pci"
-MACHINE_EXTRA_RRECOMMENDS += "\
-    linux-firmware-rpidistro-bcm43455 \
-    bluez-firmware-rpidistro-bcm4345c0-hcd \
-    linux-firmware-rpidistro-bcm43456 \
-    bluez-firmware-rpidistro-bcm4345c5-hcd \
-"
-
+require ov-raspberrypi4.inc
 require conf/machine/include/arm/armv7a/tune-cortexa7.inc
-include conf/machine/include/rpi-base.inc
+
+#RPI_KERNEL_DEVICETREE_OVERLAYS:append = " \
+#    overlays/ov-rpi4-57-lvds.dtbo \
+#"
 
 KBUILD_DEFCONFIG:ov-rpi4 ?= "bcm2711_defconfig"
 
-RPI_KERNEL_DEVICETREE ?= " \
-    broadcom/bcm2711-rpi-4-b.dtb \
-    broadcom/bcm2711-rpi-cm4.dtb \
-    broadcom/bcm2711-rpi-cm4s.dtb \
-    "
-
 # 'l' stands for LPAE
 SDIMG_KERNELIMAGE ?= "kernel7l.img"
-SERIAL_CONSOLES ?= "115200;ttyS0"
 
 UBOOT_MACHINE = "rpi_4_32b_config"
 
-#Enable u-boot
-RPI_USE_U_BOOT = "1"
-ENABLE_UART = "1"
-#Enable otg mode
-ENABLE_DWC2_HOST = "1"
-
-VC4DTBO ?= "vc4-kms-v3d"
 ARMSTUB ?= "armstub7.bin"
-
-#ov-rpi-sdimg
-IMAGE_CLASSES += "sdcard_image-ov-rpi"
-IMAGE_FSTYPES = "tar.bz2 ext3 wic.bz2 wic.bmap ov-rpi-sdimg"


### PR DESCRIPTION
With the new RPi platform 4 new machines have been created with no top-level machine. The configurations are almost the same. That's why it would make sense to create a top-level setup with all common configurations.

The `ov-rpi4.conf` has been adjusted to match the current `ov-rpi4-64.conf`. The differences were introduced in [Enable u-boot for raspberry pi](https://github.com/Openvario/meta-openvario/commit/8584038dfd30895cb798249fab9645d0a5c39f4f) and [Corrected machine settings](https://github.com/Openvario/meta-openvario/commit/d746ba6eb3fb690f5e0eeb5620d2c5e28fc9dd34).

I don't have a RaspberryPi 4 (32bit), so maybe someone could verify that it is still working on the Raspberry Pi.