### PR TITLE
xcsoar-menu/openvario.xci: Fix QuickMenu slot conflicts with XCSoar default.xci

### DIFF
--- a/meta-ov/recipes-apps/xcsoar/xcsoar-menu/openvario.xci
+++ b/meta-ov/recipes-apps/xcsoar/xcsoar-menu/openvario.xci
@@ -1,15 +1,13 @@
 # -------------
-# Define gesture to open Quickmenu without keyboard or remote
-# ("Draw a button on the screen") 
+# OpenVario-specific XCI overlay
+# Loaded after default.xci
 # -------------
 
-mode=default
-type=gesture
-data=ULDR
-event=QuickMenu
-
 # -------------
-# Define Quickmenu buttons for vario menu and quit
+# Quickmenu: Vario menu and OpenVario system buttons
+# Vario at location=18 replaces standalone MacCready,
+# which is still accessible inside the Vario_menu
+# Quit/Reboot/Shutdown use locations 61-63 (beyond default.xci range)
 # -------------
 
 mode=RemoteStick
@@ -17,7 +15,25 @@ type=key
 data=0
 event=Mode Vario_menu
 label=Vario
-location=13
+location=18
+
+# OpenVario only:
+mode=RemoteStick
+type=key
+data=0
+event=Shutdown reboot
+event=Mode default
+label=Reboot
+location=61
+
+# OpenVario only:
+mode=RemoteStick
+type=key
+data=0
+event=Shutdown shutdown
+event=Mode default
+label=Shutdown
+location=62
 
 mode=RemoteStick
 type=key
@@ -25,11 +41,11 @@ data=0
 event=Exit system
 event=Mode default
 label=Quit
-location=31
+location=63
 
 
 # -------------
-# Define Vario_menu buttons for 
+# Vario_menu: POV vario control
 # Vario app must be connected as device A
 # -------------
 
@@ -93,7 +109,7 @@ location=9
 
 
 # -------------
-# Define automatic vario / speed to fly switch
+# Automatic vario / speed to fly switch
 # Uncomment the following lines if you want to use automatic switching
 # Vario app must be connected as device A
 # -------------
@@ -111,7 +127,7 @@ location=9
 # event=StatusMessage Speed to Fly Mode
 
 # -------------
-# Define vario / speed to fly with switch on remote stick
+# Vario / speed to fly with switch on remote stick
 # Remote sends V for vario, S for STF and M for Vario_menu
 # -------------
 
@@ -124,10 +140,10 @@ event=StatusMessage Vario Mode
 mode=default
 type=key
 data=S
-event=SendNMEAPort1 POV,C,STF 
+event=SendNMEAPort1 POV,C,STF
 event=StatusMessage Speed to Fly Mode
 
 mode=default RemoteStick
 type=key
 data=M
-event=Mode Vario_menu 
+event=Mode Vario_menu


### PR DESCRIPTION
## Summary

XCSoar's `default.xci` has expanded its RemoteStick QuickMenu layout significantly (locations 1-41), causing the OpenVario overlay to silently clobber useful default buttons.

This PR fixes three conflicts:

- **Remove ULDR gesture**: already defined in `default.xci` since the QuickMenu gesture was upstreamed — the overlay copy is redundant
- **Move Vario from location=13 → 18**: location 13 is now the Task manager button; location 18 (MacCready) is a natural fit since MC+/MC- are accessible inside the Vario_menu submenu anyway
- **Move Quit from location=31 → 63**: location 31 is now the Status button; location 63 is safely beyond the default range (1-41)
- **Add Reboot (61) and Shutdown (62)** buttons for OpenVario system control, also in the safe range

### Before (conflicts)
| Location | default.xci | openvario.xci (overrides) |
|----------|-------------|---------------------------|
| 13 | Task | **Vario** (clobbers Task) |
| 31 | Status | **Quit** (clobbers Status) |

### After (no conflicts)
| Location | default.xci | openvario.xci |
|----------|-------------|---------------|
| 13 | Task | *(untouched)* |
| 18 | ~~MacCready~~ | **Vario** (MC still accessible inside Vario_menu) |
| 31 | Status | *(untouched)* |
| 61 | *(free)* | **Reboot** |
| 62 | *(free)* | **Shutdown** |
| 63 | *(free)* | **Quit** |

Fixes #406

## Test plan

- [ ] Verify QuickMenu shows Vario button near the center (location 18)
- [ ] Verify Task (13) and Status (31) buttons are no longer overridden
- [ ] Verify Reboot/Shutdown/Quit appear at the end of the QuickMenu
- [ ] Verify Vario_menu sub-mode still works (volume, STF/vario, MC+/MC-)
- [ ] Verify V/S/M key bindings still function in default mode