### PR TITLE
xcsoar: update to 7.44

### DIFF
--- a/conf/distro/ovlinux.conf
+++ b/conf/distro/ovlinux.conf
@@ -95,6 +95,7 @@ DISTRO_FEATURES:remove = "acl argp pcmcia usbgadget xattr nfs zeroconf pci 3g nf
 DISTRO_FEATURES:remove:cubieboard2 = "gobject-introspection-data"
 DISTRO_FEATURES:append:raspberrypi4 = " bluez5 bluetooth wifi glib systemd-resolved"
 DISTRO_FEATURES:append = " opensoar"
+PREFERRED_VERSION_xcsoar = "7.43"
 
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 

--- a/recipes-apps/xcsoar/xcsoar_7.44.bb
+++ b/recipes-apps/xcsoar/xcsoar_7.44.bb
@@ -1,0 +1,15 @@
+# Copyright (C) 2014 Unknow User <unknow@user.org>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+PR="r1"
+RCONFLICTS:${PN}="xcsoar-testing"
+
+SRC_URI = "git://github.com/XCSoar/XCSoar.git;protocol=https;branch=master "
+
+# Commit version for 7.44:
+SRCREV = "a0dddd9088839c64bc1cdae9422044052b479b98"
+
+BOOST_VERSION = "1.90.0"
+BOOST_SHA256HASH = "49551aff3b22cbc5c5a9ed3dbc92f0e23ea50a0f7325b0d198b705e8ee3fc305"
+
+require xcsoar.inc


### PR DESCRIPTION
When creating this branch I wasn't quite sure if we wanted to update to XCSoar 7.44 directly. That's why I created a new config and added a preferred version for XCSoar.
But I can remove the v7.43 as @Scumi proposed in #419 