### PR TITLE
CM4: remove low lcd brightness levels

### DIFF
--- a/recipes-kernel/linux/files/rpi/ov-cm4-ch57-overlay.dts
+++ b/recipes-kernel/linux/files/rpi/ov-cm4-ch57-overlay.dts
@@ -39,8 +39,8 @@
         
             lcd:lcd {
                 compatible = "pwm-backlight";
-                brightness-levels = <0 6 8 12 16 24 32 40 48 64 96 128 160 192 224 255>;
-                default-brightness-level = <15>;
+                brightness-levels = <24 32 40 48 64 96 128 160 192 224 255>;
+                default-brightness-level = <10>;
                 pwms = <&pwm 0 200000 0>;
             };
 

--- a/recipes-kernel/linux/files/rpi/ov-cm4-pq70-overlay.dts
+++ b/recipes-kernel/linux/files/rpi/ov-cm4-pq70-overlay.dts
@@ -39,8 +39,8 @@
         
             lcd: lcd {
                 compatible = "pwm-backlight";
-                brightness-levels = <0 6 8 12 16 24 32 40 48 64 96 128 160 192 224 255>;
-                default-brightness-level = <15>;
+                brightness-levels = <24 32 40 48 64 96 128 160 192 224 255>;
+                default-brightness-level = <10>;
                 pwms = <&pwm 0 200000 0>;
             };
 

--- a/recipes-kernel/linux/files/rpi/ov-rpi4-ch57-overlay.dts
+++ b/recipes-kernel/linux/files/rpi/ov-rpi4-ch57-overlay.dts
@@ -39,8 +39,8 @@
         
             lcd:lcd {
                 compatible = "pwm-backlight";
-                brightness-levels = <0 6 8 12 16 24 32 40 48 64 96 128 160 192 224 255>;
-                default-brightness-level = <15>;
+                brightness-levels = <24 32 40 48 64 96 128 160 192 224 255>;
+                default-brightness-level = <10>;
                 pwms = <&pwm 0 200000 0>;
             };
 


### PR DESCRIPTION
Removes very dark brightness levels. They were not even usable in dark environments.
However I encountered the following **issue**:
High pitch tone increasing for brightness levels from level 1 to 4 (already starting with a quiet tone at level 1) and decreasing to level 10. At level 9 it is still hearable, at level 10 the high pitch tone is gone.

Previous behavior (high pitch tone):
increasing: level 6 to 9
decreasing: level 9 to 10
levels 11 to 15 not selectable.

In addition the brightness level is not stored correctly (after reboot the default value is loaded and present in the config file). Does anyone know how it is handled on the cubieboard or what the problem could be?