### PR TITLE
Fix image naming

### DIFF
--- a/classes/sdcard_image-openvario.bbclass
+++ b/classes/sdcard_image-openvario.bbclass
@@ -143,7 +143,7 @@ IMAGE_CMD:openvario-sdimg () {
     gzip -f ${SDIMG}
 
     # create a relative link to new created image
-    ln -sfr ${SDIMG}.gz ${SDIMG_LINK}.gz
+    # ln -sfr ${SDIMG}.gz ${SDIMG_LINK}.gz
 
     # write output filename to file for upload
     echo ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME} > ${DEPLOY_DIR_IMAGE}/image_name    

--- a/conf/distro/ovlinux.conf
+++ b/conf/distro/ovlinux.conf
@@ -12,7 +12,7 @@ SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
 MAINTAINER = "Timo Bruderek <openvario@timoshome.org>"
 
 # Image Version suffix constructed from git tags and commit info
-IMAGE_NAME = "OV-${IMAGE_VERSION_SUFFIX}-${SHORT_OV_MACHINE}-${IMAGE_TYPE}"
+IMAGE_NAME = "OV-${IMAGE_VERSION_SUFFIX}-${SHORT_OV_MACHINE}${IMAGE_TYPE}"
 #IMAGE_NAME_LINK = "OV-${IMAGE_BASENAME}-glibc-ipk-current-${MACHINE}"
 
 TARGET_VENDOR = "-ovlinux"

--- a/recipes-core/images/openvario-image-testing.bb
+++ b/recipes-core/images/openvario-image-testing.bb
@@ -16,7 +16,7 @@ IMAGE_INSTALL += "\
 "
 
 export IMAGE_BASENAME = "openvario-testing"
-export IMAGE_TYPE = "testing"
+export IMAGE_TYPE = "-testing"
 
 #    sensord-testing 
 #    variod-testing 


### PR DESCRIPTION
- Fix naming of image in case of non-testing
- Remove SDLINK creation as it was created in the wrong directory and is no longer needed