### PR TITLE
xcsoar: Add sqlite3 to build dependencies

### DIFF
--- a/recipes-apps/xcsoar/xcsoar.inc
+++ b/recipes-apps/xcsoar/xcsoar.inc
@@ -26,6 +26,7 @@ DEPENDS = "	\
 		c-ares \
 		fmt \
 		dbus \
+		sqlite3 \
 "
 
 RDEPENDS:${PN} = "\


### PR DESCRIPTION
## Summary

- Add `sqlite3` to `DEPENDS` in `recipes-apps/xcsoar/xcsoar.inc`
- Fixes XCSoar compile failures after upstream started linking against `-lsqlite3`

XCSoar links against libsqlite3 on Kobo/OpenVario but does not build SQLite via `thirdparty.py` for that target (unlike Android/Darwin with GeoTIFF). The Yocto build must provide headers and `libsqlite3` in the sysroot.

## Test plan

- [x] `bitbake xcsoar` (or `xcsoar-testing`) completes without missing `-lsqlite3` / `sqlite3.h` errors
- [ ] Built `xcsoar` binary runs on device