### PR TITLE
Change submodule URLs to git.openembedded.org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "meta-openembedded"]
 	path = meta-openembedded
-	url = git://git.openembedded.org/meta-openembedded.git
+	url = https://git.openembedded.org/meta-openembedded.git
 [submodule "openembedded-core"]
 	path = openembedded-core
-	url = git://git.openembedded.org/openembedded-core
+	url = https://git.openembedded.org/openembedded-core
 [submodule "bitbake"]
 	path = bitbake
-	url = git://git.openembedded.org/bitbake
+	url = https://git.openembedded.org/bitbake
 [submodule "meta-sunxi"]
 	path = meta-sunxi
 	url = https://github.com/linux-sunxi/meta-sunxi.git


### PR DESCRIPTION
Updated submodule URLs to point to the new Git server.