### PR TITLE
RepoMgmnt: add templates for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: "\U0001F41E Bug report"
+description: Create a report to help us improve OpenVario
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve OpenVario.
+        Please provide as much detail as possible so the issue can be triaged quickly.
+  - type: dropdown
+    id: issue-area
+    attributes:
+      label: Issue area
+      description: Select the area that best matches your report.
+      options:
+        - Hardware
+        - Firmware / Embedded
+        - Software / App
+        - Documentation
+      default: 1
+    validations:
+      required: true
+  - type: textarea
+    id: device
+    attributes:
+      label: Device / hardware version
+      description: Model, machine, connected hardware / peripherals, or other relevant identifiers.
+      placeholder: e.g. OpenVario, ov-cb-ch70, external GPS, sensor module
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include firmware version, software/app (e.g. XCSoar) version
+      placeholder: Firmware version, app version
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: List the exact steps to reproduce the issue.
+      placeholder: 1. Start the device...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+      placeholder: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. What happened instead? Include errors, symptoms, or unexpected outputs.
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any pictures, wiring details, logs, or other useful context.
+  - type: textarea
+    id: related-issues
+    attributes:
+      label: Related issues
+      description: Link any related issues, pull requests, or discussion threads, if available.
+      placeholder: #123, #456
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or output
+      description: Optional if possbile paste relevant logs, serial output, error messages, or stack traces.
+      render: shell-script

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: "🚀 Feature request"
+description: Suggest a feature that will improve OpenVario
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this feature request.
+        Please describe the proposed change clearly so it can be evaluated for feasibility and priority.
+  - type: dropdown
+    id: feature-area
+    attributes:
+      label: Feature area
+      description: Select the area that best matches your proposal.
+      options:
+        - Hardware
+        - Firmware / Embedded
+        - Software / App
+        - Documentation
+      default: 1
+    validations:
+      required: true
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Describe the feature
+      description: A clear and concise description of the proposed improvement, including the use case and alternatives you have considered. If you already have a prototype or mock-up, please include it.
+      placeholder: Feature description
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation and use case
+      description: Explain why this feature would be useful and who would benefit from it.
+      placeholder: Motivation and use case
+    validations:
+      required: true
+  - type: textarea
+    id: implementation-notes
+    attributes:
+      label: Implementation notes
+      description: If relevant, add notes about hardware requirements, firmware changes, software impact, or compatibility concerns.
+      placeholder: Implementation notes
+  - type: textarea
+    id: related-issues
+    attributes:
+      label: Related issues (optional)
+      description: Link any related issues, pull requests, or discussion threads, if available.
+      placeholder: #123, #456
+  - type: checkboxes
+    id: additional-info
+    attributes:
+      label: Additional information
+      description: Additional information that helps us decide how to proceed.
+      options:
+        - label: Would you be willing to help implement this feature?
+        - label: Does this require both hardware and software changes?
+  - type: checkboxes
+    id: required-info
+    attributes:
+      label: Final checks
+      description: Before submitting, please make sure you do the following.
+      options:
+        - label: Check existing [issues](https://github.com/Openvario/meta-openvario/issues) and [discussions](https://github.com/Openvario/meta-openvario/discussions) for similar proposals.
+          required: true


### PR DESCRIPTION
Follow up of #447 
Adding templates for issues will help to get a better overview of bug reports and feature request.
I used the [nuxt issue templates](https://github.com/vuejs/core/tree/main/.github/ISSUE_TEMPLATE) to create these templates. It is just a start so it might be possible that some information is missing. If you see something that needs improvement, feel free to request changes. It is also possible to adjust these templates later. 