### PR TITLE
Add libgeotiff to XCSoar

### DIFF
--- a/recipes-apps/xcsoar/xcsoar.inc
+++ b/recipes-apps/xcsoar/xcsoar.inc
@@ -17,6 +17,8 @@ DEPENDS = "	\
 		jpeg \
 		freetype \
 		libpng \
+		tiff \
+		libgeotiff \
 		glm \
 		virtual/egl \
 		virtual/mesa \
@@ -64,7 +66,6 @@ EXTRA_OEMAKE = " \
 	\
 	DEBUG=n DEBUG_GLIBCXX=n \
 	ENABLE_MESA_KMS=y GLES2=y \
-	GEOTIFF=n \
 "
 
 do_configure() {

--- a/recipes-support/geotiff/libgeotiff_1.7.4.bb
+++ b/recipes-support/geotiff/libgeotiff_1.7.4.bb
@@ -1,0 +1,33 @@
+DESCRIPTION = "Library for reading and writing GeoTIFF files"
+HOMEPAGE = "https://github.com/OSGeo/libgeotiff"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=f80854a7049ee9433d1f93336fe22f10"
+
+DEPENDS = "tiff zlib proj"
+
+SRC_URI = "https://github.com/OSGeo/libgeotiff/releases/download/1.7.4/libgeotiff-1.7.4.tar.gz"
+SRC_URI[sha256sum] = "c598d04fdf2ba25c4352844dafa81dde3f7fd968daa7ad131228cd91e9d3dc47"
+
+inherit cmake
+
+EXTRA_OECMAKE = "-DWITH_UTILITIES=OFF -DWITH_JPEG=OFF -DCMAKE_INSTALL_PREFIX=/usr"
+
+do_install:append() {
+    mkdir -p ${D}${libdir}/pkgconfig
+    cat > ${D}${libdir}/pkgconfig/libgeotiff.pc << 'PCEOF'
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: libgeotiff
+Description: Library for reading and writing GeoTIFF files
+Version: 1.7.4
+Libs: -L${libdir} -lgeotiff
+Cflags: -I${includedir}
+Requires: proj
+PCEOF
+}
+
+FILES:${PN} = "${libdir}/libgeotiff.so.* /usr/doc"
+FILES:${PN}-dev = "${includedir} ${libdir}/libgeotiff.so ${libdir}/pkgconfig ${libdir}/cmake ${datadir}/cmake"

--- a/recipes-support/proj/proj_9.8.1.bb
+++ b/recipes-support/proj/proj_9.8.1.bb
@@ -1,0 +1,17 @@
+DESCRIPTION = "PROJ - Cartographic projections library"
+HOMEPAGE = "https://proj.org"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=f27445198ba1500f508fce2b183ce0ff"
+
+DEPENDS = "sqlite3"
+
+SRC_URI = "https://github.com/OSGeo/PROJ/releases/download/9.8.1/proj-9.8.1.tar.gz"
+SRC_URI[sha256sum] = "af5b731c145c1d13c4e3b4eeb7d167e94e845e440f71e3496b4ed8dae0291960"
+
+inherit cmake
+
+EXTRA_OECMAKE = "-DBUILD_TESTING=OFF -DBUILD_APPS=OFF -DENABLE_CURL=OFF -DENABLE_TIFF=OFF"
+
+do_install:append() {
+    rm -rf ${D}${datadir}/bash-completion
+}


### PR DESCRIPTION
XCSoar 7.45 contains several updates to weather forecasts. To enable those on OpenVario, libgeotiff needs to be added and enabled.